### PR TITLE
fix: consistently trims all login emails

### DIFF
--- a/src/features/auth/components/forgot-password-form.tsx
+++ b/src/features/auth/components/forgot-password-form.tsx
@@ -31,10 +31,14 @@ export function ForgotPasswordForm({
     setError(null);
 
     try {
+      const normalizedEmail = email.trim().toLowerCase();
       // The url which will be included in the email. This URL needs to be configured in your redirect URLs in the Supabase dashboard at https://supabase.com/dashboard/project/_/auth/url-configuration
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}/auth/update-password`,
-      });
+      const { error } = await supabase.auth.resetPasswordForEmail(
+        normalizedEmail,
+        {
+          redirectTo: `${window.location.origin}/auth/update-password`,
+        }
+      );
       if (error) throw error;
       setSuccess(true);
     } catch (error: unknown) {

--- a/src/features/auth/components/login-form.tsx
+++ b/src/features/auth/components/login-form.tsx
@@ -33,8 +33,9 @@ export function LoginForm({
     setError(null);
 
     try {
+      const normalizedEmail = email.trim().toLowerCase();
       const { error } = await supabase.auth.signInWithPassword({
-        email,
+        email: normalizedEmail,
         password,
       });
       if (error) throw error;


### PR DESCRIPTION
before: 
- during signup, called trim().toLowerCase() before sending email to supabase. however, login and forgot-password flow didn't trim or make the email lowercase, causing an inconsistency. 

after this fix:
- login and forgot-password also normalize the email, so all three flows have the same normalization.

why:
- because email is normalized anyway (eg. JohnSmith@gmail.com and johnsmith@gmail.com are treated as the exact same address.)