### PR TITLE
feat: simplify navbar and dynamically fetch homepage events

### DIFF
--- a/src/features/marketing/components/EventCard.tsx
+++ b/src/features/marketing/components/EventCard.tsx
@@ -1,33 +1,40 @@
 import React from "react";
-import Image from "next/image";
+import Link from "next/link";
 
 interface EventCardProps {
     imageSrc: string;
     imageAlt: string;
     buttonText: string;
     buttonIcon: React.ReactNode;
+    href?: string;
 }
 
 const EventCard: React.FC<EventCardProps> = ({
     imageSrc,
     imageAlt,
-    // buttonText,
-    // buttonIcon,
+    href,
 }) => {
+    const inner = (
+        <div className="overflow-hidden rounded-lg">
+            <img
+                src={imageSrc}
+                alt={imageAlt}
+                className="w-full object-contain"
+            />
+        </div>
+    );
+
+    if (href) {
+        return (
+            <Link href={href} className="flex-1 rounded-2xl border border-[#C1C7CD] p-3 block hover:opacity-90 transition-opacity">
+                {inner}
+            </Link>
+        );
+    }
+
     return (
         <div className="flex-1 rounded-2xl border border-[#C1C7CD] p-3">
-            <div className="overflow-hidden rounded-lg">
-                <img
-                    src={imageSrc}
-                    alt={imageAlt}
-                    className="w-full object-contain"
-                />
-            </div>
-
-            {/* <button className="flex items-center justify-center gap-2 w-[152px] px-[10px] py-2 rounded-[67.066px] border-[0.5px] border-white text-[16px] font-medium transition-colors hover:bg-gray-50 bg-[linear-gradient(166deg,rgba(251,248,255,0.80)_80.65%,rgba(151,149,153,0.10)_80.65%)] backdrop-blur-[0.5px]">
-                {buttonIcon}
-                {buttonText}
-            </button> */}
+            {inner}
         </div>
     );
 };

--- a/src/features/marketing/components/EventCard.tsx
+++ b/src/features/marketing/components/EventCard.tsx
@@ -17,12 +17,9 @@ const EventCard: React.FC<EventCardProps> = ({
     return (
         <div className="flex-1 rounded-2xl border border-[#C1C7CD] p-3">
             <div className="overflow-hidden rounded-lg">
-                <Image
+                <img
                     src={imageSrc}
                     alt={imageAlt}
-                    width={0}
-                    height={0}
-                    sizes="100vw"
                     className="w-full object-contain"
                 />
             </div>

--- a/src/features/marketing/components/FooterCallout.tsx
+++ b/src/features/marketing/components/FooterCallout.tsx
@@ -45,7 +45,7 @@ export default function FooterCallout() {
           </p>
 
           <div className="flex flex-col items-center justify-center gap-3 sm:flex-row pt-4">
-            <Button variant="primary" onClick={() => {window.location.href = "https://linktr.ee/ubcuxhub?fbclid=PAZXh0bgNhZW0CMTEAAaf0yjegrtGiSXfSFyHbl76u5TnYyGoUSImwqeW6vbKvy74Cz_NmVY6_HVuUdw_aem_gG2KbQMNO5Yidm2tSQOltA"}}>
+            <Button variant="primary" onClick={() => { window.location.href = "/portal/profile"; }}>
               BECOME A MEMBER
             </Button>
 

--- a/src/features/marketing/homepage-sections/EventsSection.tsx
+++ b/src/features/marketing/homepage-sections/EventsSection.tsx
@@ -1,10 +1,29 @@
-import React from "react";
+"use client";
+
+import React, { useEffect, useState } from "react";
 import Button from "@/features/marketing/components/Button";
 import EventCard from "@/features/marketing/components/EventCard";
-import { EVENTS } from "@/features/marketing/lib/events";
-import type { MarketingEventCard } from "@/features/marketing/types";
+import { createClient } from "@/lib/supabase/client";
+import type { EventRow } from "@/types/models";
 
 const EventsSection: React.FC = () => {
+  const [events, setEvents] = useState<EventRow[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const supabase = createClient();
+    async function fetchEvents() {
+      const { data, error } = await supabase
+        .from("events")
+        .select("*")
+        .order("start_date", { ascending: true })
+        .limit(2);
+      if (!error && data) setEvents(data);
+      setLoading(false);
+    }
+    fetchEvents();
+  }, []);
+
   const triangleIcon = (
     <svg
       width="16"
@@ -44,11 +63,6 @@ const EventsSection: React.FC = () => {
     </svg>
   );
 
-  const iconByType: Record<MarketingEventCard["icon"], React.ReactNode> = {
-    triangle: triangleIcon,
-    star: starIcon,
-  };
-
   return (
     <div id="events" className="px-[5%] md:px-[20%]">
       <div className="mb-8">
@@ -62,19 +76,29 @@ const EventsSection: React.FC = () => {
 
       {/* event cards */}
       <div className="flex flex-col md:flex-row">
-        {EVENTS.map((event, index) => (
-          <React.Fragment key={event.imageSrc}>
-            <EventCard
-              imageSrc={event.imageSrc}
-              imageAlt={event.imageAlt}
-              buttonText={event.buttonText}
-              buttonIcon={iconByType[event.icon]}
-            />
-            {index < EVENTS.length - 1 && (
-              <div className="md:w-[5%] h-8" aria-hidden="true"></div>
-            )}
-          </React.Fragment>
-        ))}
+        {loading ? (
+          <div className="flex w-full justify-center py-20">
+            <div className="animate-spin rounded-full h-8 w-8 border-2 border-black border-t-transparent"></div>
+          </div>
+        ) : events.length === 0 ? (
+          <div className="text-center w-full py-20 border border-dashed border-gray-300 rounded-xl">
+            <h3 className="text-lg font-semibold text-gray-700">No events scheduled yet</h3>
+          </div>
+        ) : (
+          events.map((event, index) => (
+            <React.Fragment key={event.id}>
+              <EventCard
+                imageSrc={event.image_url || "/events/event1.png"}
+                imageAlt={event.name || "Event Image"}
+                buttonText={index % 2 === 0 ? "office tour" : "competition"}
+                buttonIcon={index % 2 === 0 ? triangleIcon : starIcon}
+              />
+              {index < events.length - 1 && (
+                <div className="md:w-[5%] h-8" aria-hidden="true"></div>
+              )}
+            </React.Fragment>
+          ))
+        )}
       </div>
 
       {/* CTA */}

--- a/src/features/marketing/homepage-sections/EventsSection.tsx
+++ b/src/features/marketing/homepage-sections/EventsSection.tsx
@@ -92,6 +92,7 @@ const EventsSection: React.FC = () => {
                 imageAlt={event.name || "Event Image"}
                 buttonText={index % 2 === 0 ? "office tour" : "competition"}
                 buttonIcon={index % 2 === 0 ? triangleIcon : starIcon}
+                href={`/portal/events/${event.id}`}
               />
               {index < events.length - 1 && (
                 <div className="md:w-[5%] h-8" aria-hidden="true"></div>

--- a/src/features/marketing/homepage-sections/HeroSection.tsx
+++ b/src/features/marketing/homepage-sections/HeroSection.tsx
@@ -164,7 +164,7 @@ export default function Hero() {
             </p>
 
             <div className="mt-10 flex gap-4 sm:mt-12 md:mt-14">
-              <Button variant="primary" onClick={() => {window.location.href = "https://linktr.ee/ubcuxhub?fbclid=PAZXh0bgNhZW0CMTEAAaf0yjegrtGiSXfSFyHbl76u5TnYyGoUSImwqeW6vbKvy74Cz_NmVY6_HVuUdw_aem_gG2KbQMNO5Yidm2tSQOltA"}}>
+              <Button variant="primary" onClick={() => { window.location.href = "/portal/profile"; }}>
                 BECOME A MEMBER
               </Button>
             </div>

--- a/src/features/marketing/homepage-sections/Navbar.tsx
+++ b/src/features/marketing/homepage-sections/Navbar.tsx
@@ -49,7 +49,7 @@ export default function Navbar() {
               Contact Us
             </Link>
 
-            <Button variant="primary" withArrow={false} shorterHeight={true} onClick={() => {}}>
+            <Button variant="primary" withArrow={false} shorterHeight={true} onClick={() => { window.location.href = "/portal/profile"; }}>
               BECOME A MEMBER
             </Button>
           </div>

--- a/src/features/marketing/homepage-sections/Navbar.tsx
+++ b/src/features/marketing/homepage-sections/Navbar.tsx
@@ -24,7 +24,7 @@ export default function Navbar() {
     <div className="fixed inset-x-0 top-0 z-50 bg-white py-1">
       <nav className="flex h-20 items-center md:px-[5%] px-[5%]">
         {/* Logo */}
-        <Link href="#home" className="block" onClick={close}>
+        <Link href="/" className="block" onClick={close}>
           <div className="w-[48px] h-[48px]">
             <Image
               src="/logo.png"
@@ -39,23 +39,17 @@ export default function Navbar() {
 
         <div className="ml-auto hidden md:flex items-center">
           <div className="flex items-center gap-8">
-            <Link href="#home" className={navLink}>
+            <Link href="/" className={navLink}>
               Home
             </Link>
-            <Link href="#about-us" className={navLink}>
-              About Us
-            </Link>
-            <Link href="#events" className={navLink}>
+            <Link href="/events" className={navLink}>
               Events
-            </Link>
-            <Link href="#team" className={navLink}>
-              Meet the Team
             </Link>
             <Link href="mailto:ubcuxhub@gmail.com" className={navLink}>
               Contact Us
             </Link>
 
-            <Button variant="primary" withArrow={false} shorterHeight={true}  onClick={() => {window.location.href = "https://linktr.ee/ubcuxhub?fbclid=PAZXh0bgNhZW0CMTEAAaf0yjegrtGiSXfSFyHbl76u5TnYyGoUSImwqeW6vbKvy74Cz_NmVY6_HVuUdw_aem_gG2KbQMNO5Yidm2tSQOltA"}}>
+            <Button variant="primary" withArrow={false} shorterHeight={true} onClick={() => {}}>
               BECOME A MEMBER
             </Button>
           </div>
@@ -86,17 +80,11 @@ export default function Navbar() {
             role="menu"
           >
             <div className="flex flex-col p-3">
-              <Link href="#home" className={`${navLink} px-3 py-2`} onClick={close}>
+              <Link href="/" className={`${navLink} px-3 py-2`} onClick={close}>
                 Home
               </Link>
-              <Link href="#about-us" className={`${navLink} px-3 py-2`} onClick={close}>
-                About Us
-              </Link>
-              <Link href="#events" className={`${navLink} px-3 py-2`} onClick={close}>
+              <Link href="/events" className={`${navLink} px-3 py-2`} onClick={close}>
                 Events
-              </Link>
-              <Link href="#team" className={`${navLink} px-3 py-2`} onClick={close}>
-                Meet the Team
               </Link>
               <Link
                 href="mailto:ubcuxhub@gmail.com"


### PR DESCRIPTION
This PR simplifies the main navigation and updates the homepage to feature dynamic event data fetched directly from our database. 

Simplified Navbar (`Navbar.tsx`):
  - Reduced the top menu to four primary actions: Home, Events, Contact Us, and Become a Member.
  - Updated the "Home" and Logo links to direct to `/` instead of `#home`.
  - Updated the "Events" link to point directly to `/events` instead of the homepage anchor.

Dynamic Homepage Events (`EventsSection.tsx` & `EventCard.tsx`)
  - Refactored `EventsSection` into a client component.
  - Replaced the hardcoded, static `EVENTS` array with a dynamic data fetch from the Supabase `events` table 