### PR TITLE
Allow events to be deleted if no successful purchases exist

### DIFF
--- a/src/features/admin/components/DeleteEventModal.tsx
+++ b/src/features/admin/components/DeleteEventModal.tsx
@@ -60,13 +60,16 @@ export function DeleteEventModal({
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div
-            className="text-sm text-muted-foreground"
-            dangerouslySetInnerHTML={{
-              __html:
-                "Are you sure you want to delete this event? This action cannot be undone.<br />Type in the event name to delete this event forever.",
-            }}
-          />
+          <div className="space-y-2 text-sm text-muted-foreground">
+            <p>
+              Are you sure you want to delete this event? This action cannot be
+              undone.
+            </p>
+            <p>
+              Type in the event name <strong>{eventName}</strong> to delete
+              this event forever.
+            </p>
+          </div>
           <div className="space-y-2">
             <Input
               type="text"

--- a/src/features/admin/components/EventCreateModify.tsx
+++ b/src/features/admin/components/EventCreateModify.tsx
@@ -24,6 +24,10 @@ import {
 } from "@/lib/supabase-helpers/event-applications";
 import { deleteRegistrationsForEvent } from "@/lib/supabase-helpers/event-registrations";
 import {
+  deleteFailedPurchasesForEvent,
+  ensureEventPurchasesAreDeletable,
+} from "@/lib/supabase-helpers/purchases";
+import {
   ResponseType,
   type ApplicationQuestionTemplate,
 } from "@/features/events/types/eventTypes";
@@ -1052,6 +1056,19 @@ export const EventCreateModify = ({
     setError(null);
 
     try {
+      // Purchases restrict event deletion. Fail before removing other event data.
+      try {
+        await ensureEventPurchasesAreDeletable(supabase, eventId);
+      } catch (checkPurchasesError) {
+        const message =
+          checkPurchasesError instanceof Error
+            ? checkPurchasesError.message
+            : "Unknown error";
+        setError(message);
+        setIsDeleting(false);
+        return;
+      }
+
       // Delete related check-in sessions first
       try {
         await deleteCheckInSessionsForEvent(supabase, eventId);
@@ -1087,6 +1104,19 @@ export const EventCreateModify = ({
             ? deleteRegistrationsError.message
             : "Unknown error";
         setError(`Failed to delete event registrations: ${message}`);
+        setIsDeleting(false);
+        return;
+      }
+
+      // Delete failed purchases that would otherwise block event deletion
+      try {
+        await deleteFailedPurchasesForEvent(supabase, eventId);
+      } catch (deletePurchasesError) {
+        const message =
+          deletePurchasesError instanceof Error
+            ? deletePurchasesError.message
+            : "Unknown error";
+        setError(`Failed to delete event purchases: ${message}`);
         setIsDeleting(false);
         return;
       }

--- a/src/lib/supabase-helpers/purchases.ts
+++ b/src/lib/supabase-helpers/purchases.ts
@@ -14,6 +14,13 @@ export interface PurchaseWithDetails extends PurchaseRow {
   membership_types: Pick<MembershipTypeRow, "id" | "name" | "slug"> | null;
 }
 
+type EventPurchaseSummary = Pick<PurchaseRow, "id" | "status">;
+
+const SUCCESSFUL_EVENT_PURCHASE_DELETE_WARNING =
+  "Unable to delete the event, there exists successful user purchases relating to the event. Please contact the development team for assistance.";
+
+const SUCCESSFUL_PURCHASE_STATUSES = new Set(["authorized", "completed"]);
+
 export async function createPurchase(
   supabase: DbClient,
   payload: PurchaseInsert
@@ -84,6 +91,65 @@ export async function updatePurchase(
 
   if (error) throw error;
   return data;
+}
+
+async function fetchEventPurchaseSummaries(
+  supabase: DbClient,
+  eventId: string
+): Promise<EventPurchaseSummary[]> {
+  const { data, error } = await supabase
+    .from(TABLES.purchases)
+    .select("id, status")
+    .eq("event_id", eventId);
+
+  if (error) throw error;
+  return data ?? [];
+}
+
+function assertOnlyFailedPurchases(purchases: EventPurchaseSummary[]): void {
+  const hasSuccessfulPurchase = purchases.some((purchase) =>
+    SUCCESSFUL_PURCHASE_STATUSES.has(purchase.status)
+  );
+
+  if (hasSuccessfulPurchase) {
+    throw new Error(SUCCESSFUL_EVENT_PURCHASE_DELETE_WARNING);
+  }
+
+  const hasBlockingPurchase = purchases.some(
+    (purchase) => purchase.status !== "failed"
+  );
+
+  if (hasBlockingPurchase) {
+    throw new Error(
+      "This event has purchases that are not failed, so it cannot be deleted."
+    );
+  }
+}
+
+export async function ensureEventPurchasesAreDeletable(
+  supabase: DbClient,
+  eventId: string
+): Promise<void> {
+  const purchases = await fetchEventPurchaseSummaries(supabase, eventId);
+  assertOnlyFailedPurchases(purchases);
+}
+
+export async function deleteFailedPurchasesForEvent(
+  supabase: DbClient,
+  eventId: string
+): Promise<void> {
+  const purchases = await fetchEventPurchaseSummaries(supabase, eventId);
+  if (purchases.length === 0) return;
+
+  assertOnlyFailedPurchases(purchases);
+
+  const purchaseIds = purchases.map((purchase) => purchase.id);
+  const { error: deleteError } = await supabase
+    .from(TABLES.purchases)
+    .delete()
+    .in("id", purchaseIds);
+
+  if (deleteError) throw deleteError;
 }
 
 export async function fetchPurchasesForUser(

--- a/supabase/migrations/20260709223500_allow_admin_delete_failed_event_purchases.sql
+++ b/supabase/migrations/20260709223500_allow_admin_delete_failed_event_purchases.sql
@@ -1,0 +1,31 @@
+drop policy if exists "admin can select purchases" on public.purchases;
+drop policy if exists "admin can delete failed event purchases" on public.purchases;
+
+create policy "admin can select purchases"
+on public.purchases
+for select
+to authenticated
+using (
+  exists (
+    select 1
+    from public.user_info u
+    where u.auth_user_id = auth.uid()
+      and u.role_access = 'admin'::public.role_access_enum
+  )
+);
+
+create policy "admin can delete failed event purchases"
+on public.purchases
+for delete
+to authenticated
+using (
+  kind = 'event_ticket'
+  and status = 'failed'
+  and event_id is not null
+  and exists (
+    select 1
+    from public.user_info u
+    where u.auth_user_id = auth.uid()
+      and u.role_access = 'admin'::public.role_access_enum
+  )
+);


### PR DESCRIPTION
#67 

Add a descriptive message to warn if the event has successful purchases relating to it. Otherwise, allow deletion of the event.

Waiting on https://github.com/ubcuxhub/uxhub/pull/81 to be merged to run `pnpm supabase db push`.
