### PR TITLE
fix: teach tailwind-merge about the custom typography scale

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { cn } from "./utils";
+
+const typeScaleClasses = [
+  "text-h1",
+  "text-h2",
+  "text-h3",
+  "text-subheading",
+  "text-body",
+  "text-small",
+  "text-label",
+  "text-table",
+  "text-button",
+  "text-badge",
+];
+
+describe("cn", () => {
+  it.each(typeScaleClasses)(
+    "keeps %s alongside a text color",
+    (fontSize) => {
+      expect(cn(fontSize, "text-muted-foreground")).toBe(
+        `${fontSize} text-muted-foreground`
+      );
+      expect(cn("text-muted-foreground", fontSize)).toBe(
+        `text-muted-foreground ${fontSize}`
+      );
+    }
+  );
+
+  it("lets a custom font size override another custom font size", () => {
+    expect(cn("text-h3", "text-h2", "text-success")).toBe(
+      "text-h2 text-success"
+    );
+  });
+
+  it("lets a built-in font size override a custom one", () => {
+    expect(cn("text-h3", "text-sm", "text-success")).toBe(
+      "text-sm text-success"
+    );
+  });
+
+  it("lets a custom font size override a built-in one", () => {
+    expect(cn("text-sm", "text-h3", "text-success")).toBe(
+      "text-h3 text-success"
+    );
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,28 @@
 import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { extendTailwindMerge } from "tailwind-merge"
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      "font-size": [
+        {
+          text: [
+            "h1",
+            "h2",
+            "h3",
+            "subheading",
+            "body",
+            "small",
+            "label",
+            "table",
+            "button",
+            "badge",
+          ],
+        },
+      ],
+    },
+  },
+})
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))


### PR DESCRIPTION
Recovers `6300391` from `feat/dialog-purchasing-flow`, the last commit on that branch with content not already in `main` (its other patches landed via #89 and #90). Found during branch cleanup.

## The bug

`globals.css` defines ten custom font sizes as Tailwind 4 theme variables (`--text-h1`, `--text-subheading`, `--text-small`, …), used ~200 times across the app. But `cn()` merges with stock `twMerge`, which has no idea those exist. Since it can't classify `text-small`, it falls back to treating any unknown `text-*` as a **text color** — so a custom scale and a real color land in the same conflict group and one gets dropped.

This is live in five shipped primitives today:

| Call site | Input | Actually renders | Dropped |
|---|---|---|---|
| `card.tsx:45` CardDescription | `text-muted-foreground text-small` | `text-small` | the color |
| `dialog.tsx:120` DialogDescription | `text-small text-muted-foreground` | `text-muted-foreground` | the size |
| `field.tsx:229` FieldError | `text-small text-destructive` | `text-destructive` | the size |
| `sheet.tsx:115` SheetTitle | `text-subheading text-foreground` | `text-foreground` | the size |
| `sheet.tsx:128` SheetDescription | `text-small text-muted-foreground` | `text-muted-foreground` | the size |

Plain `className="text-small text-muted-foreground"` on a raw element is unaffected — the classes only collide when merged through `cn()`.

## The fix

Registers the ten names under tailwind-merge's `font-size` group via `extendTailwindMerge`. They now conflict with each other and with built-ins (`text-sm` beats `text-h3`, and vice versa by order) but no longer with colors.

## Notes

- **This changes rendered output** — by design. The five primitives above regain their dropped class, so `CardDescription` becomes muted again and dialog/sheet/field text picks up its intended size. Worth an eyeball on dialogs and sheets after merge.
- The original commit shipped a `node --test` runner; `main` has since adopted vitest, so I dropped that script and rewrote the test as `src/lib/utils.test.ts` in the existing colocated style. Verified it fails against `main`'s `utils.ts` and passes with the fix.
- `pnpm lint` (0 errors), `pnpm exec tsc --noEmit`, `pnpm test` (72 passed), and `pnpm build` all pass. The lone lint warning is pre-existing in `src/features/marketing/components/EventCard.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)