### PR TITLE
Add realistic local seed users and relative event timelines

### DIFF
--- a/scripts/seed/data/events.ts
+++ b/scripts/seed/data/events.ts
@@ -1,21 +1,23 @@
 /**
- * Two full seasons of events: 2025-26 (past) and 2026-27 (upcoming).
+ * A relative event timeline with past, ongoing, and upcoming fixtures.
  *
  * Conventions:
- * - Recurring events are slugged with the calendar year they happen in, so one
- *   academic year spans two suffixes (design-sprint-2026 + uxathon-2027).
+ * - Slugs are stable seed identities. Visible names and years move relative to
+ *   the seed run so existing database rows update instead of duplicating.
  * - `start_time` / `end_time` are `time` columns: naive local wall-clock, no offset.
- * - `registration_*_time` are `timestamptz`: explicit America/Vancouver offsets,
- *   -07:00 during PDT and -08:00 during PST (DST ends the first Sunday of November).
- * - Registration opens ~6 weeks before an event and closes ~5 days before, which
- *   also keeps `registration_end_time >= registration_start_time` (events_check1).
- * - Check-in session times are absolute ISO timestamps rather than offsets from the
- *   event start. The previous script derived them with
- *   `start.setHours(start.getHours() + offsetHours)`, which truncates fractional
- *   hours to zero and silently placed sessions at the wrong time.
+ * - `registration_*_time` and check-in sessions are generated as absolute UTC
+ *   timestamps. Event `time` columns remain naive local wall-clock values.
  */
 
 import type { TablesInsert } from "../../../src/lib/supabase/database.types.ts";
+import {
+  addDays,
+  addMonths,
+  dateString,
+  eventYear,
+  startOfUtcDay,
+  timestamp,
+} from "../lib/relative-dates.ts";
 
 /**
  * Shapes of the `mentors` and `agenda` JSONB columns.
@@ -338,11 +340,40 @@ const applicationQuestions = {
   ],
 };
 
-export const seedEvents: SeedEvent[] = [
-  /* ── 2025-26 season ─────────────────────────────────────────────────── */
+export function buildSeedEvents(now: Date): SeedEvent[] {
+  const today = startOfUtcDay(now);
+  const schedule = {
+    getToKnowPast: addMonths(today, -12),
+    designSprintPast: addMonths(today, -10),
+    uxathonPast: addMonths(today, -8),
+    thinkboxPast: addMonths(today, -4),
+    industryTalkPast: addMonths(today, -2),
+    mentorshipStart: addMonths(today, -1),
+    mentorshipEnd: addMonths(today, 18),
+    openStudioStart: addMonths(today, -6),
+    openStudioEnd: addMonths(today, 24),
+    coffeeSeriesStart: addMonths(today, -3),
+    coffeeSeriesEnd: addMonths(today, 9),
+    studentPanelFuture: addMonths(today, 12),
+    designSprintFuture: addMonths(today, 24),
+    uxathonFuture: addMonths(today, 18),
+    thinkboxFuture: addMonths(today, 22),
+  } as const;
+
+  const historicalRegistration = (eventDate: Date) => ({
+    start: timestamp(addMonths(eventDate, -2)),
+    end: timestamp(addDays(eventDate, -5), 23, 59),
+  });
+  const openFutureRegistration = (eventDate: Date) => ({
+    start: timestamp(addMonths(today, -1)),
+    end: timestamp(addDays(eventDate, -5), 23, 59),
+  });
+
+  return [
+  /* ── Past events ────────────────────────────────────────────────────── */
   {
     event: {
-      name: "Get to Know UX Hub 2025",
+      name: `Get to Know UX Hub ${eventYear(schedule.getToKnowPast)}`,
       slug: "get-to-know-ux-hub-2025",
       description:
         "Our first event of the year and the easiest way to meet everyone. Short intro to what UX Hub runs across the year, a design-themed icebreaker, and plenty of time to talk to the exec team. No experience needed and nothing to prepare — come find out whether this is your kind of club.",
@@ -351,28 +382,28 @@ export const seedEvents: SeedEvent[] = [
       location_building: "AMS Nest",
       location_room: "Room 2314",
       location_address_url: "https://maps.app.goo.gl/9x8k2Qm4Zt6bXQ5s7",
-      start_date: "2025-10-03",
+      start_date: dateString(schedule.getToKnowPast),
       start_time: "17:30:00",
-      end_date: "2025-10-03",
+      end_date: dateString(schedule.getToKnowPast),
       end_time: "19:30:00",
       max_capacity: 120,
       image_url:
         "https://images.unsplash.com/photo-1511578314322-379afb476865?auto=format&fit=crop&q=80&w=800&h=800",
-      registration_start_time: "2025-08-22T00:00:00-07:00",
-      registration_end_time: "2025-09-28T23:59:00-07:00",
+      registration_start_time: historicalRegistration(schedule.getToKnowPast).start,
+      registration_end_time: historicalRegistration(schedule.getToKnowPast).end,
     },
     checkInSessions: [
       {
         name: "Door Check-in",
-        start_time: "2025-10-03T17:15:00-07:00",
-        end_time: "2025-10-03T18:30:00-07:00",
+        start_time: timestamp(schedule.getToKnowPast, 17, 15),
+        end_time: timestamp(schedule.getToKnowPast, 18, 30),
       },
     ],
     applicationQuestions: [],
   },
   {
     event: {
-      name: "Design Sprint 2025",
+      name: `Design Sprint ${eventYear(schedule.designSprintPast)}`,
       slug: "design-sprint-2025",
       description:
         "One day, one brief, one clickable prototype. Teams of four run a compressed design sprint from problem framing through guerrilla research to a final critique in front of working designers. Our biggest first-term event and the fastest way to get something real into your portfolio.",
@@ -381,15 +412,15 @@ export const seedEvents: SeedEvent[] = [
       location_building: "Neville Scarfe Building",
       location_room: "Room 100",
       location_address_url: "https://maps.app.goo.gl/vNq7CkS3Wm2hZr4A9",
-      start_date: "2025-10-25",
+      start_date: dateString(schedule.designSprintPast),
       start_time: "10:00:00",
-      end_date: "2025-10-25",
+      end_date: dateString(schedule.designSprintPast),
       end_time: "17:00:00",
       max_capacity: 60,
       image_url:
         "https://images.unsplash.com/photo-1531403009284-440f080d1e12?auto=format&fit=crop&q=80&w=800&h=800",
-      registration_start_time: "2025-09-13T00:00:00-07:00",
-      registration_end_time: "2025-10-20T23:59:00-07:00",
+      registration_start_time: historicalRegistration(schedule.designSprintPast).start,
+      registration_end_time: historicalRegistration(schedule.designSprintPast).end,
       mentors: designSprintMentors,
       agenda: designSprintAgenda,
       sponsor_logos: [
@@ -404,52 +435,52 @@ export const seedEvents: SeedEvent[] = [
     checkInSessions: [
       {
         name: "Morning Check-in",
-        start_time: "2025-10-25T09:45:00-07:00",
-        end_time: "2025-10-25T10:45:00-07:00",
+        start_time: timestamp(schedule.designSprintPast, 9, 45),
+        end_time: timestamp(schedule.designSprintPast, 10, 45),
       },
       {
         name: "Post-Lunch Check-in",
-        start_time: "2025-10-25T13:45:00-07:00",
-        end_time: "2025-10-25T14:30:00-07:00",
+        start_time: timestamp(schedule.designSprintPast, 13, 45),
+        end_time: timestamp(schedule.designSprintPast, 14, 30),
       },
     ],
     applicationQuestions: applicationQuestions.designSprint,
   },
   {
     event: {
-      name: "Student Panel 2025",
+      name: `Student Design Mentorship Program ${eventYear(schedule.mentorshipStart)}–${eventYear(schedule.mentorshipEnd)} [ongoing]`,
       slug: "student-panel-2025",
       description:
-        "Four students and recent grads talk through how they actually got into UX — the switched majors, the rejected portfolios, the co-op that changed everything. Honest answers rather than a polished career-fair pitch, followed by open Q&A and networking.",
-      regular_price: 0,
-      member_price: 0,
+        "A long-running mentorship program pairing students with peer and industry mentors. Members join monthly critiques, portfolio working sessions, and career conversations throughout the program.",
+      regular_price: 20,
+      member_price: 10,
       location_building: "Life Sciences Centre",
       location_room: "Atrium",
       location_address_url: "https://maps.app.goo.gl/T4wR8bLp1Vz6Yn3H8",
-      start_date: "2025-11-13",
+      start_date: dateString(schedule.mentorshipStart),
       start_time: "18:00:00",
-      end_date: "2025-11-13",
+      end_date: dateString(schedule.mentorshipEnd),
       end_time: "20:00:00",
       max_capacity: 100,
       image_url:
         "https://images.unsplash.com/photo-1475721027785-f74eccf877e2?auto=format&fit=crop&q=80&w=800&h=800",
-      registration_start_time: "2025-10-02T00:00:00-07:00",
-      registration_end_time: "2025-11-08T23:59:00-08:00",
+      registration_start_time: timestamp(addMonths(schedule.mentorshipStart, -3)),
+      registration_end_time: timestamp(schedule.mentorshipEnd, 23, 59),
       mentors: panelMentors,
       agenda: panelAgenda,
     },
     checkInSessions: [
       {
         name: "Door Check-in",
-        start_time: "2025-11-13T17:45:00-08:00",
-        end_time: "2025-11-13T19:00:00-08:00",
+        start_time: timestamp(schedule.mentorshipStart, 17, 45),
+        end_time: timestamp(schedule.mentorshipEnd, 19),
       },
     ],
     applicationQuestions: [],
   },
   {
     event: {
-      name: "UXathon 2026",
+      name: `UXathon ${eventYear(schedule.uxathonPast)}`,
       slug: "uxathon-2026",
       description:
         "Our flagship event: 32 hours, one open-ended brief, and a room full of teams turning it into something defensible. Mentors from across the Vancouver design scene rotate through all weekend, and the final round is judged on how well you argue for your decisions — not just how good the screens look. Food, snacks, and swag included.",
@@ -458,15 +489,15 @@ export const seedEvents: SeedEvent[] = [
       location_building: "ICICS/CS X-wing",
       location_room: "Room 100",
       location_address_url: "https://maps.app.goo.gl/6dK2sYqR8fV1nB7t5",
-      start_date: "2026-01-24",
+      start_date: dateString(schedule.uxathonPast),
       start_time: "09:00:00",
-      end_date: "2026-01-25",
+      end_date: dateString(addDays(schedule.uxathonPast, 1)),
       end_time: "17:00:00",
       max_capacity: 80,
       image_url:
         "https://images.unsplash.com/photo-1542744173-8e7e53415bb0?auto=format&fit=crop&q=80&w=800&h=800",
-      registration_start_time: "2025-12-12T00:00:00-08:00",
-      registration_end_time: "2026-01-19T23:59:00-08:00",
+      registration_start_time: historicalRegistration(schedule.uxathonPast).start,
+      registration_end_time: historicalRegistration(schedule.uxathonPast).end,
       mentors: uxathonMentors,
       agenda: [...uxathonAgendaDayOne, ...uxathonAgendaDayTwo],
       sponsor_logos: [
@@ -482,25 +513,25 @@ export const seedEvents: SeedEvent[] = [
     checkInSessions: [
       {
         name: "Opening Ceremony Check-in",
-        start_time: "2026-01-24T08:45:00-08:00",
-        end_time: "2026-01-24T10:30:00-08:00",
+        start_time: timestamp(schedule.uxathonPast, 8, 45),
+        end_time: timestamp(schedule.uxathonPast, 10, 30),
       },
       {
         name: "Evening Headcount",
-        start_time: "2026-01-24T19:00:00-08:00",
-        end_time: "2026-01-24T20:00:00-08:00",
+        start_time: timestamp(schedule.uxathonPast, 19),
+        end_time: timestamp(schedule.uxathonPast, 20),
       },
       {
         name: "Final Presentations Check-in",
-        start_time: "2026-01-25T12:30:00-08:00",
-        end_time: "2026-01-25T13:30:00-08:00",
+        start_time: timestamp(addDays(schedule.uxathonPast, 1), 12, 30),
+        end_time: timestamp(addDays(schedule.uxathonPast, 1), 13, 30),
       },
     ],
     applicationQuestions: applicationQuestions.uxathon,
   },
   {
     event: {
-      name: "Thinkbox Office Tour 2026",
+      name: `Thinkbox Office Tour ${eventYear(schedule.thinkboxPast)}`,
       slug: "thinkbox-office-tour-2026",
       description:
         "A small-group visit to Thinkbox's Vancouver studio. Walk the space, see how their design team actually works day to day, and stay for an informal Q&A with two of their product designers. Capacity is tight because they are hosting us in one room — sign up early.",
@@ -509,33 +540,33 @@ export const seedEvents: SeedEvent[] = [
       location_building: "Thinkbox Studio",
       location_room: "Main Lobby",
       location_address_url: "https://maps.app.goo.gl/PLACEHOLDER-thinkbox",
-      start_date: "2026-02-11",
+      start_date: dateString(schedule.thinkboxPast),
       start_time: "14:00:00",
-      end_date: "2026-02-11",
+      end_date: dateString(schedule.thinkboxPast),
       end_time: "16:00:00",
       max_capacity: 25,
       image_url:
         "https://images.unsplash.com/photo-1497366216548-37526070297c?auto=format&fit=crop&q=80&w=800&h=800",
-      registration_start_time: "2025-12-31T00:00:00-08:00",
-      registration_end_time: "2026-02-06T23:59:00-08:00",
+      registration_start_time: historicalRegistration(schedule.thinkboxPast).start,
+      registration_end_time: historicalRegistration(schedule.thinkboxPast).end,
     },
     checkInSessions: [
       {
         name: "Campus Departure",
-        start_time: "2026-02-11T13:00:00-08:00",
-        end_time: "2026-02-11T13:20:00-08:00",
+        start_time: timestamp(schedule.thinkboxPast, 13),
+        end_time: timestamp(schedule.thinkboxPast, 13, 20),
       },
       {
         name: "Lobby Check-in",
-        start_time: "2026-02-11T13:50:00-08:00",
-        end_time: "2026-02-11T14:20:00-08:00",
+        start_time: timestamp(schedule.thinkboxPast, 13, 50),
+        end_time: timestamp(schedule.thinkboxPast, 14, 20),
       },
     ],
     applicationQuestions: [],
   },
   {
     event: {
-      name: "Industry Talk: AI and UX 2026",
+      name: `Industry Talk: AI and UX ${eventYear(schedule.industryTalkPast)}`,
       slug: "industry-talk-ai-and-ux-2026",
       description:
         "A working designer walks through what actually changed in their process once AI tooling landed in it — what they use, what they abandoned, and which parts of the job turned out to be stubbornly human. Talk, then a long Q&A.",
@@ -544,60 +575,60 @@ export const seedEvents: SeedEvent[] = [
       location_building: "Henry Angus Building",
       location_room: "Room 241",
       location_address_url: "https://maps.app.goo.gl/Mn5vJ2Xa7Rq9Ld3W6",
-      start_date: "2026-03-10",
+      start_date: dateString(schedule.industryTalkPast),
       start_time: "18:00:00",
-      end_date: "2026-03-10",
+      end_date: dateString(schedule.industryTalkPast),
       end_time: "19:30:00",
       max_capacity: 80,
       image_url:
         "https://images.unsplash.com/photo-1531482615713-2afd69097998?auto=format&fit=crop&q=80&w=800&h=800",
-      registration_start_time: "2026-01-27T00:00:00-08:00",
-      registration_end_time: "2026-03-05T23:59:00-08:00",
+      registration_start_time: historicalRegistration(schedule.industryTalkPast).start,
+      registration_end_time: historicalRegistration(schedule.industryTalkPast).end,
     },
     checkInSessions: [
       {
         name: "Door Check-in",
-        start_time: "2026-03-10T17:45:00-07:00",
-        end_time: "2026-03-10T18:45:00-07:00",
+        start_time: timestamp(schedule.industryTalkPast, 17, 45),
+        end_time: timestamp(schedule.industryTalkPast, 18, 45),
       },
     ],
     applicationQuestions: [],
   },
 
-  /* ── 2026-27 season ─────────────────────────────────────────────────── */
+  /* ── Ongoing and upcoming events ────────────────────────────────────── */
   {
     event: {
-      name: "Get to Know UX Hub 2026",
+      name: `UX Hub Open Studio ${eventYear(schedule.openStudioStart)}–${eventYear(schedule.openStudioEnd)} [ongoing]`,
       slug: "get-to-know-ux-hub-2026",
       description:
-        "New year, same idea: come meet the club before committing to anything. Quick tour of what we run across both terms, a design-themed icebreaker, and time to ask the exec team whatever you want. Free, no experience needed, and the single best entry point if you are new to UX.",
+        "An always-on home base for the UX Hub community. Drop into recurring critique circles, co-working sessions, and open office hours throughout the program window.",
       regular_price: 0,
       member_price: 0,
       location_building: "AMS Nest",
       location_room: "Room 2314",
       location_address_url: "https://maps.app.goo.gl/9x8k2Qm4Zt6bXQ5s7",
-      start_date: "2026-10-02",
+      start_date: dateString(schedule.openStudioStart),
       start_time: "17:30:00",
-      end_date: "2026-10-02",
+      end_date: dateString(schedule.openStudioEnd),
       end_time: "19:30:00",
       max_capacity: 120,
       image_url:
         "https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?auto=format&fit=crop&q=80&w=800&h=800",
-      registration_start_time: "2026-08-21T00:00:00-07:00",
-      registration_end_time: "2026-09-27T23:59:00-07:00",
+      registration_start_time: timestamp(addMonths(schedule.openStudioStart, -2)),
+      registration_end_time: timestamp(schedule.openStudioEnd, 23, 59),
     },
     checkInSessions: [
       {
         name: "Door Check-in",
-        start_time: "2026-10-02T17:15:00-07:00",
-        end_time: "2026-10-02T18:30:00-07:00",
+        start_time: timestamp(schedule.openStudioStart, 17, 15),
+        end_time: timestamp(schedule.openStudioEnd, 18, 30),
       },
     ],
     applicationQuestions: [],
   },
   {
     event: {
-      name: "Design Sprint 2026",
+      name: `Design Sprint ${eventYear(schedule.designSprintFuture)} [registration open]`,
       slug: "design-sprint-2026",
       description:
         "One day, one brief, one clickable prototype. Teams of four run a compressed design sprint from problem framing through guerrilla research to a final critique in front of working designers. Our biggest first-term event and the fastest way to get something real into your portfolio.",
@@ -606,15 +637,15 @@ export const seedEvents: SeedEvent[] = [
       location_building: "Neville Scarfe Building",
       location_room: "Room 100",
       location_address_url: "https://maps.app.goo.gl/vNq7CkS3Wm2hZr4A9",
-      start_date: "2026-10-24",
+      start_date: dateString(schedule.designSprintFuture),
       start_time: "10:00:00",
-      end_date: "2026-10-24",
+      end_date: dateString(schedule.designSprintFuture),
       end_time: "17:00:00",
       max_capacity: 60,
       image_url:
         "https://images.unsplash.com/photo-1599305445671-ac291c95aaa9?auto=format&fit=crop&q=80&w=800&h=800",
-      registration_start_time: "2026-09-12T00:00:00-07:00",
-      registration_end_time: "2026-10-19T23:59:00-07:00",
+      registration_start_time: openFutureRegistration(schedule.designSprintFuture).start,
+      registration_end_time: openFutureRegistration(schedule.designSprintFuture).end,
       mentors: designSprintMentors,
       agenda: designSprintAgenda,
       sponsor_logos: [
@@ -629,20 +660,20 @@ export const seedEvents: SeedEvent[] = [
     checkInSessions: [
       {
         name: "Morning Check-in",
-        start_time: "2026-10-24T09:45:00-07:00",
-        end_time: "2026-10-24T10:45:00-07:00",
+        start_time: timestamp(schedule.designSprintFuture, 9, 45),
+        end_time: timestamp(schedule.designSprintFuture, 10, 45),
       },
       {
         name: "Post-Lunch Check-in",
-        start_time: "2026-10-24T13:45:00-07:00",
-        end_time: "2026-10-24T14:30:00-07:00",
+        start_time: timestamp(schedule.designSprintFuture, 13, 45),
+        end_time: timestamp(schedule.designSprintFuture, 14, 30),
       },
     ],
     applicationQuestions: applicationQuestions.designSprint,
   },
   {
     event: {
-      name: "Student Panel 2026",
+      name: `Student Panel ${eventYear(schedule.studentPanelFuture)}`,
       slug: "student-panel-2026",
       description:
         "Four students and recent grads talk through how they actually got into UX — the switched majors, the rejected portfolios, the co-op that changed everything. Honest answers rather than a polished career-fair pitch, followed by open Q&A and networking.",
@@ -651,60 +682,60 @@ export const seedEvents: SeedEvent[] = [
       location_building: "Life Sciences Centre",
       location_room: "Atrium",
       location_address_url: "https://maps.app.goo.gl/T4wR8bLp1Vz6Yn3H8",
-      start_date: "2026-11-12",
+      start_date: dateString(schedule.studentPanelFuture),
       start_time: "18:00:00",
-      end_date: "2026-11-12",
+      end_date: dateString(schedule.studentPanelFuture),
       end_time: "20:00:00",
       max_capacity: 100,
       image_url:
         "https://images.unsplash.com/photo-1522071820081-009f0129c71c?auto=format&fit=crop&q=80&w=800&h=800",
-      registration_start_time: "2026-10-01T00:00:00-07:00",
-      registration_end_time: "2026-11-07T23:59:00-08:00",
+      registration_start_time: timestamp(addMonths(today, 6)),
+      registration_end_time: timestamp(addDays(schedule.studentPanelFuture, -5), 23, 59),
       mentors: panelMentors,
       agenda: panelAgenda,
     },
     checkInSessions: [
       {
         name: "Door Check-in",
-        start_time: "2026-11-12T17:45:00-08:00",
-        end_time: "2026-11-12T19:00:00-08:00",
+        start_time: timestamp(schedule.studentPanelFuture, 17, 45),
+        end_time: timestamp(schedule.studentPanelFuture, 19),
       },
     ],
     applicationQuestions: [],
   },
   {
     event: {
-      name: "Coffee Chat Social 2026",
+      name: `Coffee Chat Community Series ${eventYear(schedule.coffeeSeriesStart)}–${eventYear(schedule.coffeeSeriesEnd)} [ongoing]`,
       slug: "coffee-chat-social-2026",
       description:
-        "A low-key end-of-term social. Coffee, pastries, and rotating small-group chats so you actually talk to people instead of standing near them. Bring a work-in-progress if you want feedback, or bring nothing at all.",
+        "A recurring low-key social series with coffee, pastries, rotating small-group chats, and optional feedback on work in progress.",
       regular_price: 0,
       member_price: 0,
       location_building: "AMS Nest",
       location_room: "Room 2306",
       location_address_url: "https://maps.app.goo.gl/9x8k2Qm4Zt6bXQ5s7",
-      start_date: "2026-11-25",
+      start_date: dateString(schedule.coffeeSeriesStart),
       start_time: "16:00:00",
-      end_date: "2026-11-25",
+      end_date: dateString(schedule.coffeeSeriesEnd),
       end_time: "18:00:00",
       max_capacity: 40,
       image_url:
         "https://images.unsplash.com/photo-1552664730-d307ca884978?auto=format&fit=crop&q=80&w=800&h=800",
-      registration_start_time: "2026-10-14T00:00:00-07:00",
-      registration_end_time: "2026-11-20T23:59:00-08:00",
+      registration_start_time: timestamp(addMonths(schedule.coffeeSeriesStart, -2)),
+      registration_end_time: timestamp(schedule.coffeeSeriesEnd, 23, 59),
     },
     checkInSessions: [
       {
         name: "Door Check-in",
-        start_time: "2026-11-25T15:50:00-08:00",
-        end_time: "2026-11-25T17:00:00-08:00",
+        start_time: timestamp(schedule.coffeeSeriesStart, 15, 50),
+        end_time: timestamp(schedule.coffeeSeriesEnd, 17),
       },
     ],
     applicationQuestions: [],
   },
   {
     event: {
-      name: "UXathon 2027",
+      name: `UXathon ${eventYear(schedule.uxathonFuture)} [registration open]`,
       slug: "uxathon-2027",
       description:
         "Our flagship event: 32 hours, one open-ended brief, and a room full of teams turning it into something defensible. Mentors from across the Vancouver design scene rotate through all weekend, and the final round is judged on how well you argue for your decisions — not just how good the screens look. Food, snacks, and swag included.",
@@ -713,15 +744,15 @@ export const seedEvents: SeedEvent[] = [
       location_building: "ICICS/CS X-wing",
       location_room: "Room 100",
       location_address_url: "https://maps.app.goo.gl/6dK2sYqR8fV1nB7t5",
-      start_date: "2027-01-23",
+      start_date: dateString(schedule.uxathonFuture),
       start_time: "09:00:00",
-      end_date: "2027-01-24",
+      end_date: dateString(addDays(schedule.uxathonFuture, 1)),
       end_time: "17:00:00",
       max_capacity: 80,
       image_url:
         "https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&q=80&w=800&h=800",
-      registration_start_time: "2026-12-11T00:00:00-08:00",
-      registration_end_time: "2027-01-18T23:59:00-08:00",
+      registration_start_time: openFutureRegistration(schedule.uxathonFuture).start,
+      registration_end_time: openFutureRegistration(schedule.uxathonFuture).end,
       mentors: uxathonMentors,
       agenda: [...uxathonAgendaDayOne, ...uxathonAgendaDayTwo],
       sponsor_logos: [
@@ -737,25 +768,25 @@ export const seedEvents: SeedEvent[] = [
     checkInSessions: [
       {
         name: "Opening Ceremony Check-in",
-        start_time: "2027-01-23T08:45:00-08:00",
-        end_time: "2027-01-23T10:30:00-08:00",
+        start_time: timestamp(schedule.uxathonFuture, 8, 45),
+        end_time: timestamp(schedule.uxathonFuture, 10, 30),
       },
       {
         name: "Evening Headcount",
-        start_time: "2027-01-23T19:00:00-08:00",
-        end_time: "2027-01-23T20:00:00-08:00",
+        start_time: timestamp(schedule.uxathonFuture, 19),
+        end_time: timestamp(schedule.uxathonFuture, 20),
       },
       {
         name: "Final Presentations Check-in",
-        start_time: "2027-01-24T12:30:00-08:00",
-        end_time: "2027-01-24T13:30:00-08:00",
+        start_time: timestamp(addDays(schedule.uxathonFuture, 1), 12, 30),
+        end_time: timestamp(addDays(schedule.uxathonFuture, 1), 13, 30),
       },
     ],
     applicationQuestions: applicationQuestions.uxathon,
   },
   {
     event: {
-      name: "Thinkbox Office Tour 2027",
+      name: `Thinkbox Office Tour ${eventYear(schedule.thinkboxFuture)} [registration open]`,
       slug: "thinkbox-office-tour-2027",
       description:
         "A small-group visit to Thinkbox's Vancouver studio. Walk the space, see how their design team actually works day to day, and stay for an informal Q&A with two of their product designers. Capacity is tight because they are hosting us in one room — sign up early.",
@@ -764,28 +795,31 @@ export const seedEvents: SeedEvent[] = [
       location_building: "Thinkbox Studio",
       location_room: "Main Lobby",
       location_address_url: "https://maps.app.goo.gl/PLACEHOLDER-thinkbox",
-      start_date: "2027-02-10",
+      start_date: dateString(schedule.thinkboxFuture),
       start_time: "14:00:00",
-      end_date: "2027-02-10",
+      end_date: dateString(schedule.thinkboxFuture),
       end_time: "16:00:00",
       max_capacity: 25,
       image_url:
         "https://images.unsplash.com/photo-1611162616475-46b635cb6868?auto=format&fit=crop&q=80&w=800&h=800",
-      registration_start_time: "2026-12-30T00:00:00-08:00",
-      registration_end_time: "2027-02-05T23:59:00-08:00",
+      registration_start_time: openFutureRegistration(schedule.thinkboxFuture).start,
+      registration_end_time: openFutureRegistration(schedule.thinkboxFuture).end,
     },
     checkInSessions: [
       {
         name: "Campus Departure",
-        start_time: "2027-02-10T13:00:00-08:00",
-        end_time: "2027-02-10T13:20:00-08:00",
+        start_time: timestamp(schedule.thinkboxFuture, 13),
+        end_time: timestamp(schedule.thinkboxFuture, 13, 20),
       },
       {
         name: "Lobby Check-in",
-        start_time: "2027-02-10T13:50:00-08:00",
-        end_time: "2027-02-10T14:20:00-08:00",
+        start_time: timestamp(schedule.thinkboxFuture, 13, 50),
+        end_time: timestamp(schedule.thinkboxFuture, 14, 20),
       },
     ],
     applicationQuestions: [],
   },
-];
+  ];
+}
+
+export const seedEvents = buildSeedEvents(new Date());

--- a/scripts/seed/data/users.ts
+++ b/scripts/seed/data/users.ts
@@ -1,0 +1,351 @@
+import type { TablesInsert } from "../../../src/lib/supabase/database.types.ts";
+import { addDays, startOfUtcDay, timestamp } from "../lib/relative-dates.ts";
+import { seedEvents, type SeedEvent } from "./events.ts";
+
+export interface SeedPurchase {
+  amountCents: number;
+  createdAt: string;
+  eventSlug?: string;
+  failureReason?: string;
+  fulfilledAt?: string;
+  idempotencyKey: string;
+  kind: "event_ticket" | "membership";
+  membershipSlug?: string;
+  squarePaymentId?: string;
+  status: "pending" | "authorized" | "completed" | "canceled" | "failed";
+}
+
+export interface SeedRegistration {
+  attending: boolean;
+  checkIns?: Record<string, string>;
+  eventSlug: string;
+  purchaseKey?: string;
+  responses?: Record<string, string>;
+  reviewerEmail?: string;
+  status: "pending" | "declined" | "accepted";
+}
+
+export interface SeedUser {
+  email: string;
+  membershipSlug: string | null;
+  password: string;
+  profile: Omit<
+    TablesInsert<"user_info">,
+    | "auth_user_id"
+    | "email"
+    | "membership_expires_at"
+    | "membership_pre_ordered_type_id"
+    | "membership_type_id"
+  >;
+  purchases: SeedPurchase[];
+  registrations: SeedRegistration[];
+}
+
+const designSprintQuestions = {
+  year: "What year of study are you in?",
+  figma: "How would you describe your experience with Figma?",
+  goal: "What do you want to walk away from the Design Sprint with? Two or three sentences is plenty.",
+  dietary: "Any dietary restrictions we should know about for lunch?",
+} as const;
+
+const uxathonQuestions = {
+  year: "What year of study are you in?",
+  contribution: "Which area do you most want to contribute in?",
+  experience: "Have you participated in a hackathon or design sprint before?",
+  problem: "Tell us about a design problem you have worked on recently. What was hard about it?",
+  teammates: "Are you applying with teammates? List their names and we will keep you together.",
+} as const;
+
+function requireEvent(events: SeedEvent[], slug: string): SeedEvent {
+  const event = events.find((candidate) => candidate.event.slug === slug);
+  if (!event) throw new Error(`Missing seed event "${slug}"`);
+  return event;
+}
+
+function ticketPriceCents(event: SeedEvent, isMember: boolean): number {
+  const price = isMember ? event.event.member_price : event.event.regular_price;
+  return Math.round(Number(price) * 100);
+}
+
+function afterTimestamp(value: string, minutes: number): string {
+  return new Date(new Date(value).getTime() + minutes * 60 * 1000).toISOString();
+}
+
+export function buildSeedUsers(events: SeedEvent[], now: Date): SeedUser[] {
+  const today = startOfUtcDay(now);
+  const designSprintPast = requireEvent(events, "design-sprint-2025");
+  const uxathonPast = requireEvent(events, "uxathon-2026");
+  const designSprintFuture = requireEvent(events, "design-sprint-2026");
+  const industryTalkPast = requireEvent(events, "industry-talk-ai-and-ux-2026");
+  const mentorshipOngoing = requireEvent(events, "student-panel-2025");
+  const thinkboxFuture = requireEvent(events, "thinkbox-office-tour-2027");
+  const industryCheckIn = industryTalkPast.checkInSessions[0]?.start_time;
+  const designSprintCheckIns = designSprintPast.checkInSessions;
+
+  if (!industryCheckIn || designSprintCheckIns.length < 2) {
+    throw new Error("Purchased event fixtures need their expected check-in sessions");
+  }
+
+  const historicalPurchaseTime = (event: SeedEvent) => {
+    const registrationStart = event.event.registration_start_time;
+    if (!registrationStart) throw new Error(`Event "${event.event.slug}" has no registration start`);
+    return afterTimestamp(registrationStart, 24 * 60);
+  };
+  const futurePurchaseTime = timestamp(addDays(today, -7), 18);
+  const failedPurchaseTime = timestamp(addDays(today, -3), 18);
+
+  return [
+  {
+    email: "admin-explorer@gmail.com",
+    password: "ux-hub",
+    membershipSlug: "explorer",
+    profile: {
+      name: "Admin Explorer",
+      phone: "6045550101",
+      student_number: 10000001,
+      faculty: "Faculty of Arts",
+      major: "Cognitive Systems",
+      year: "3",
+      role_access: "admin",
+      user_type: "ubcStudent",
+      dietary_restrictions: "Vegetarian",
+      newsletter: true,
+      preferred_pronouns: "they/them",
+      square_customer_id: null,
+    },
+    purchases: [
+      {
+        amountCents: 1200,
+        createdAt: timestamp(addDays(today, -30), 17),
+        fulfilledAt: timestamp(addDays(today, -30), 17, 1),
+        idempotencyKey: "seed:membership:admin-explorer:explorer",
+        kind: "membership",
+        membershipSlug: "explorer",
+        squarePaymentId: "seed:payment:admin-explorer:explorer",
+        status: "completed",
+      },
+      {
+        amountCents: ticketPriceCents(industryTalkPast, true),
+        createdAt: historicalPurchaseTime(industryTalkPast),
+        eventSlug: industryTalkPast.event.slug,
+        fulfilledAt: afterTimestamp(historicalPurchaseTime(industryTalkPast), 1),
+        idempotencyKey: "seed:event:admin-explorer:industry-talk-ai-and-ux-2026",
+        kind: "event_ticket",
+        squarePaymentId:
+          "seed:payment:admin-explorer:industry-talk-ai-and-ux-2026",
+        status: "completed",
+      },
+      {
+        amountCents: ticketPriceCents(mentorshipOngoing, true),
+        createdAt: historicalPurchaseTime(mentorshipOngoing),
+        eventSlug: mentorshipOngoing.event.slug,
+        fulfilledAt: afterTimestamp(historicalPurchaseTime(mentorshipOngoing), 1),
+        idempotencyKey: "seed:event:admin-explorer:student-panel-2025",
+        kind: "event_ticket",
+        squarePaymentId: "seed:payment:admin-explorer:student-panel-2025",
+        status: "completed",
+      },
+      {
+        amountCents: ticketPriceCents(thinkboxFuture, true),
+        createdAt: futurePurchaseTime,
+        eventSlug: thinkboxFuture.event.slug,
+        fulfilledAt: afterTimestamp(futurePurchaseTime, 1),
+        idempotencyKey: "seed:event:admin-explorer:thinkbox-office-tour-2027",
+        kind: "event_ticket",
+        squarePaymentId:
+          "seed:payment:admin-explorer:thinkbox-office-tour-2027",
+        status: "completed",
+      },
+    ],
+    registrations: [
+      {
+        eventSlug: industryTalkPast.event.slug,
+        purchaseKey:
+          "seed:event:admin-explorer:industry-talk-ai-and-ux-2026",
+        status: "accepted",
+        attending: true,
+        checkIns: {
+          "Door Check-in": afterTimestamp(industryCheckIn, 8),
+        },
+      },
+      {
+        eventSlug: mentorshipOngoing.event.slug,
+        purchaseKey: "seed:event:admin-explorer:student-panel-2025",
+        status: "accepted",
+        attending: true,
+      },
+      {
+        eventSlug: thinkboxFuture.event.slug,
+        purchaseKey:
+          "seed:event:admin-explorer:thinkbox-office-tour-2027",
+        status: "accepted",
+        attending: true,
+      },
+      {
+        eventSlug: designSprintPast.event.slug,
+        status: "accepted",
+        attending: true,
+        responses: {
+          [designSprintQuestions.year]: "3",
+          [designSprintQuestions.figma]: "Comfortable building screens",
+          [designSprintQuestions.goal]:
+            "I want to practice turning research into a focused prototype and get more confident presenting design decisions.",
+          [designSprintQuestions.dietary]: "Vegetarian",
+        },
+        checkIns: {
+          "Morning Check-in": afterTimestamp(
+            designSprintCheckIns[0].start_time!,
+            6
+          ),
+          "Post-Lunch Check-in": afterTimestamp(
+            designSprintCheckIns[1].start_time!,
+            7
+          ),
+        },
+      },
+      {
+        eventSlug: uxathonPast.event.slug,
+        status: "declined",
+        attending: false,
+        responses: {
+          [uxathonQuestions.year]: "3",
+          [uxathonQuestions.contribution]: "User research, Prototyping",
+          [uxathonQuestions.experience]: "Once or twice",
+          [uxathonQuestions.problem]:
+            "I worked on a campus wayfinding concept. The hardest part was separating navigation problems from gaps in the underlying signage system.",
+          [uxathonQuestions.teammates]: "",
+        },
+      },
+      {
+        eventSlug: designSprintFuture.event.slug,
+        status: "pending",
+        attending: false,
+        responses: {
+          [designSprintQuestions.year]: "3",
+          [designSprintQuestions.figma]:
+            "I build components and use auto-layout daily",
+          [designSprintQuestions.goal]:
+            "I want to mentor newer teammates while sharpening how I scope research under a tight deadline.",
+          [designSprintQuestions.dietary]: "Vegetarian",
+        },
+      },
+    ],
+  },
+  {
+    email: "not-member@gmail.com",
+    password: "ux-hub",
+    membershipSlug: null,
+    profile: {
+      name: "Not Member",
+      phone: "6045550102",
+      student_number: 10000002,
+      faculty: "Faculty of Science",
+      major: "Computer Science",
+      year: "2",
+      role_access: "basic",
+      user_type: "ubcStudent",
+      dietary_restrictions: null,
+      newsletter: false,
+      preferred_pronouns: "she/her",
+      square_customer_id: null,
+    },
+    purchases: [
+      {
+        amountCents: ticketPriceCents(industryTalkPast, false),
+        createdAt: historicalPurchaseTime(industryTalkPast),
+        eventSlug: industryTalkPast.event.slug,
+        fulfilledAt: afterTimestamp(historicalPurchaseTime(industryTalkPast), 1),
+        idempotencyKey: "seed:event:not-member:industry-talk-ai-and-ux-2026",
+        kind: "event_ticket",
+        squarePaymentId:
+          "seed:payment:not-member:industry-talk-ai-and-ux-2026",
+        status: "completed",
+      },
+      {
+        amountCents: ticketPriceCents(mentorshipOngoing, false),
+        createdAt: historicalPurchaseTime(mentorshipOngoing),
+        eventSlug: mentorshipOngoing.event.slug,
+        fulfilledAt: afterTimestamp(historicalPurchaseTime(mentorshipOngoing), 1),
+        idempotencyKey: "seed:event:not-member:student-panel-2025",
+        kind: "event_ticket",
+        squarePaymentId: "seed:payment:not-member:student-panel-2025",
+        status: "completed",
+      },
+      {
+        amountCents: ticketPriceCents(thinkboxFuture, false),
+        createdAt: futurePurchaseTime,
+        eventSlug: thinkboxFuture.event.slug,
+        fulfilledAt: afterTimestamp(futurePurchaseTime, 1),
+        idempotencyKey:
+          "seed:event:not-member:thinkbox-office-tour-2027:completed",
+        kind: "event_ticket",
+        squarePaymentId:
+          "seed:payment:not-member:thinkbox-office-tour-2027:completed",
+        status: "completed",
+      },
+      {
+        amountCents: ticketPriceCents(thinkboxFuture, false),
+        createdAt: failedPurchaseTime,
+        eventSlug: thinkboxFuture.event.slug,
+        failureReason: "Seeded card decline for testing",
+        idempotencyKey: "seed:event:not-member:thinkbox-office-tour-2027:failed",
+        kind: "event_ticket",
+        status: "failed",
+      },
+    ],
+    registrations: [
+      {
+        eventSlug: industryTalkPast.event.slug,
+        purchaseKey: "seed:event:not-member:industry-talk-ai-and-ux-2026",
+        status: "accepted",
+        attending: true,
+        checkIns: {
+          "Door Check-in": afterTimestamp(industryCheckIn, 8),
+        },
+      },
+      {
+        eventSlug: mentorshipOngoing.event.slug,
+        purchaseKey: "seed:event:not-member:student-panel-2025",
+        status: "accepted",
+        attending: true,
+      },
+      {
+        eventSlug: thinkboxFuture.event.slug,
+        purchaseKey:
+          "seed:event:not-member:thinkbox-office-tour-2027:completed",
+        status: "accepted",
+        attending: true,
+      },
+      {
+        eventSlug: uxathonPast.event.slug,
+        reviewerEmail: "admin-explorer@gmail.com",
+        status: "declined",
+        attending: false,
+        responses: {
+          [uxathonQuestions.year]: "2",
+          [uxathonQuestions.contribution]:
+            "Visual and UI design, Content and copy",
+          [uxathonQuestions.experience]: "No, this is my first",
+          [uxathonQuestions.problem]:
+            "I redesigned a course-registration flow. The difficult part was showing prerequisite conflicts without overwhelming students.",
+          [uxathonQuestions.teammates]: "Jordan Lee",
+        },
+      },
+      {
+        eventSlug: designSprintFuture.event.slug,
+        status: "pending",
+        attending: false,
+        responses: {
+          [designSprintQuestions.year]: "2",
+          [designSprintQuestions.figma]: "I can follow a tutorial",
+          [designSprintQuestions.goal]:
+            "I want to experience an end-to-end design process and leave with a project I can keep developing.",
+          [designSprintQuestions.dietary]: "None",
+        },
+      },
+    ],
+  },
+  ];
+}
+
+export const seedUsers = buildSeedUsers(seedEvents, new Date());

--- a/scripts/seed/index.ts
+++ b/scripts/seed/index.ts
@@ -2,7 +2,7 @@
  * Seeds a local Supabase database with realistic UX Hub data.
  *
  *   pnpm seed                      # seed everything
- *   pnpm seed -- --only=events     # memberships | events (comma-separated)
+ *   pnpm seed -- --only=events     # memberships | events | users (comma-separated)
  *   pnpm seed -- --dry-run         # print the plan, write nothing
  *   pnpm seed -- --prune           # delete seed-managed children no longer in the data
  *   pnpm seed -- --allow-remote    # required to target a non-local Supabase
@@ -26,7 +26,10 @@ import {
   type ReconcileOptions,
 } from "./lib/reconcile.ts";
 import { membershipTypes } from "./data/membership-types.ts";
-import { seedEvents } from "./data/events.ts";
+import { buildSeedEvents } from "./data/events.ts";
+import { buildSeedUsers } from "./data/users.ts";
+import { reconcileUserFixtures } from "./lib/reconcile-users.ts";
+import { validateUserFixtures } from "./lib/user-fixtures.ts";
 
 const TABLE = {
   membershipTypes: "membership_types",
@@ -65,7 +68,7 @@ function parseArgs(argv: string[]): Options {
     }
   }
 
-  const known = new Set(["memberships", "events"]);
+  const known = new Set(["memberships", "events", "users"]);
   for (const target of only) {
     if (!known.has(target)) {
       throw new Error(
@@ -87,9 +90,26 @@ function shouldRun(options: Options, target: string): boolean {
  * bypasses RLS entirely, so pointing it at the deployed project by way of a
  * stale .env.local would let it rewrite production rows.
  */
-function assertLocalTarget(url: string, allowRemote: boolean): void {
+function isLocalTarget(url: string): boolean {
   const host = new URL(url).hostname;
-  const isLocal = host === "127.0.0.1" || host === "localhost" || host === "[::1]";
+  return host === "127.0.0.1" || host === "localhost" || host === "[::1]";
+}
+
+function assertAllowedTarget(
+  url: string,
+  allowRemote: boolean,
+  includesUsers: boolean
+): void {
+  const host = new URL(url).hostname;
+  const isLocal = isLocalTarget(url);
+
+  if (!isLocal && includesUsers) {
+    throw new Error(
+      `Refusing to seed known-password users into non-local Supabase at ${host}.\n` +
+        `  User fixtures are local-only. For remote reference data, use\n` +
+        `  --only=memberships,events --allow-remote.`
+    );
+  }
 
   if (isLocal || allowRemote) {
     if (!isLocal) {
@@ -113,6 +133,10 @@ function format(label: string, counts: Counts): string {
 
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
+  const seedNow = new Date();
+  const seedEvents = buildSeedEvents(seedNow);
+  const seedUsers = buildSeedUsers(seedEvents, seedNow);
+  validateUserFixtures(seedUsers, seedEvents, membershipTypes, seedNow);
 
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const secretKey = process.env.SUPABASE_SECRET_KEY;
@@ -124,7 +148,7 @@ async function main(): Promise<void> {
     );
   }
 
-  assertLocalTarget(url, options.allowRemote);
+  assertAllowedTarget(url, options.allowRemote, shouldRun(options, "users"));
 
   if (options.dryRun) {
     console.log("Dry run — no writes will be made.\n");
@@ -197,6 +221,22 @@ async function main(): Promise<void> {
 
     summary.push(format("Check-in sessions", sessionCounts));
     summary.push(format("Application questions", questionCounts));
+  }
+
+  if (shouldRun(options, "users")) {
+    const userSummary = await reconcileUserFixtures(supabase, seedUsers, {
+      allowPlannedDependencies:
+        options.dryRun &&
+        shouldRun(options, "memberships") &&
+        shouldRun(options, "events"),
+      dryRun: options.dryRun,
+    });
+    summary.push(format("Auth users", userSummary.authUsers));
+    summary.push(format("User profiles", userSummary.profiles));
+    summary.push(format("Purchases", userSummary.purchases));
+    summary.push(format("Event registrations", userSummary.registrations));
+    summary.push(format("Application responses", userSummary.responses));
+    summary.push(format("Check-ins", userSummary.checkIns));
   }
 
   console.log(summary.join("\n"));

--- a/scripts/seed/lib/event-timeline.test.ts
+++ b/scripts/seed/lib/event-timeline.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSeedEvents } from "../data/events.ts";
+import { classifySeedEvent } from "./user-fixtures.ts";
+
+const fixedNow = new Date("2026-07-31T19:00:00.000Z");
+const events = buildSeedEvents(fixedNow);
+
+describe("relative event seed timeline", () => {
+  it("builds the intended past, ongoing, and upcoming distribution", () => {
+    const counts = { past: 0, ongoing: 0, upcoming: 0 };
+    for (const event of events) counts[classifySeedEvent(event, fixedNow)] += 1;
+
+    expect(counts).toEqual({ past: 5, ongoing: 3, upcoming: 4 });
+  });
+
+  it("keeps long-running events active with registration open", () => {
+    const ongoing = events.filter(
+      (event) => classifySeedEvent(event, fixedNow) === "ongoing"
+    );
+
+    expect(ongoing).toHaveLength(3);
+    for (const event of ongoing) {
+      expect(event.event.name).toContain("[ongoing]");
+      expect(new Date(event.event.registration_start_time!).getTime()).toBeLessThan(
+        fixedNow.getTime()
+      );
+      expect(new Date(event.event.registration_end_time!).getTime()).toBeGreaterThan(
+        fixedNow.getTime()
+      );
+    }
+
+    const longestEnd = Math.max(
+      ...ongoing.map((event) => new Date(`${event.event.end_date}T23:59:59Z`).getTime())
+    );
+    expect(longestEnd - fixedNow.getTime()).toBeGreaterThan(
+      18 * 30 * 24 * 60 * 60 * 1000
+    );
+  });
+
+  it("marks exactly the far-future events whose registration is open", () => {
+    const marked = events.filter((event) =>
+      event.event.name.endsWith("[registration open]")
+    );
+
+    expect(marked).toHaveLength(3);
+    for (const event of marked) {
+      expect(classifySeedEvent(event, fixedNow)).toBe("upcoming");
+      expect(new Date(event.event.registration_start_time!).getTime()).toBeLessThan(
+        fixedNow.getTime()
+      );
+      expect(new Date(event.event.registration_end_time!).getTime()).toBeGreaterThan(
+        fixedNow.getTime()
+      );
+    }
+
+    const studentPanel = events.find(
+      (event) => event.event.slug === "student-panel-2026"
+    );
+    expect(studentPanel).toBeDefined();
+    expect(new Date(studentPanel!.event.registration_start_time!).getTime()).toBeGreaterThan(
+      fixedNow.getTime()
+    );
+    expect(studentPanel!.event.name).not.toContain("[registration open]");
+  });
+
+  it("keeps historical registration windows closed and slugs stable", () => {
+    const past = events.filter(
+      (event) => classifySeedEvent(event, fixedNow) === "past"
+    );
+    for (const event of past) {
+      expect(new Date(event.event.registration_end_time!).getTime()).toBeLessThan(
+        fixedNow.getTime()
+      );
+    }
+
+    expect(events.map((event) => event.event.slug)).toEqual([
+      "get-to-know-ux-hub-2025",
+      "design-sprint-2025",
+      "student-panel-2025",
+      "uxathon-2026",
+      "thinkbox-office-tour-2026",
+      "industry-talk-ai-and-ux-2026",
+      "get-to-know-ux-hub-2026",
+      "design-sprint-2026",
+      "student-panel-2026",
+      "coffee-chat-social-2026",
+      "uxathon-2027",
+      "thinkbox-office-tour-2027",
+    ]);
+  });
+});

--- a/scripts/seed/lib/reconcile-users.ts
+++ b/scripts/seed/lib/reconcile-users.ts
@@ -1,0 +1,883 @@
+import type { SupabaseClient, User } from "@supabase/supabase-js";
+
+import type { SeedUser } from "../data/users.ts";
+import { emptyCounts, type Counts } from "./reconcile.ts";
+import { getUserFixtureTotals } from "./user-fixtures.ts";
+
+const TABLE = {
+  checkInSessions: "check_in_sessions",
+  checkIns: "check_ins",
+  eventApplicationQuestions: "event_application_questions",
+  eventApplicationResponses: "event_application_responses",
+  eventRegistrations: "event_registrations",
+  events: "events",
+  membershipTypes: "membership_types",
+  purchases: "purchases",
+  userInfo: "user_info",
+} as const;
+
+interface UserSeedOptions {
+  allowPlannedDependencies: boolean;
+  dryRun: boolean;
+}
+
+export interface UserSeedSummary {
+  authUsers: Counts;
+  profiles: Counts;
+  purchases: Counts;
+  registrations: Counts;
+  responses: Counts;
+  checkIns: Counts;
+}
+
+interface ProfileRow {
+  auth_user_id: string | null;
+  email: string;
+  id: string;
+}
+
+interface DependencyReferences {
+  complete: boolean;
+  eventIds: Map<string, string>;
+  membershipIds: Map<string, string>;
+  questionIds: Map<string, string>;
+  sessionIds: Map<string, string>;
+}
+
+interface IdentityState {
+  authByEmail: Map<string, User>;
+  profileByAuthId: Map<string, ProfileRow>;
+  profileByEmail: Map<string, ProfileRow>;
+}
+
+function key(...parts: string[]): string {
+  return parts.join("\u0000");
+}
+
+function countsFor(total: number, existing: number): Counts {
+  return { created: total - existing, updated: existing, pruned: 0 };
+}
+
+function createdCounts(total: number): Counts {
+  return { created: total, updated: 0, pruned: 0 };
+}
+
+function emptySummary(): UserSeedSummary {
+  return {
+    authUsers: emptyCounts(),
+    profiles: emptyCounts(),
+    purchases: emptyCounts(),
+    registrations: emptyCounts(),
+    responses: emptyCounts(),
+    checkIns: emptyCounts(),
+  };
+}
+
+async function listAllAuthUsers(supabase: SupabaseClient): Promise<User[]> {
+  const users: User[] = [];
+  const perPage = 100;
+
+  for (let page = 1; ; page += 1) {
+    const { data, error } = await supabase.auth.admin.listUsers({ page, perPage });
+    if (error) throw new Error(`Reading Auth users failed: ${error.message}`);
+
+    users.push(...data.users);
+    if (data.users.length < perPage) return users;
+  }
+}
+
+async function inspectIdentityState(
+  supabase: SupabaseClient,
+  fixtures: SeedUser[]
+): Promise<IdentityState> {
+  const authUsers = await listAllAuthUsers(supabase);
+  const fixtureEmails = fixtures.map((fixture) => fixture.email);
+  const authByEmail = new Map<string, User>();
+
+  for (const authUser of authUsers) {
+    const email = authUser.email?.trim().toLowerCase();
+    if (email && fixtureEmails.includes(email)) authByEmail.set(email, authUser);
+  }
+
+  const authIds = [...authByEmail.values()].map((user) => user.id);
+  const byEmailResult = await supabase
+    .from(TABLE.userInfo)
+    .select("id, email, auth_user_id")
+    .in("email", fixtureEmails);
+  if (byEmailResult.error) {
+    throw new Error(`Reading user profiles failed: ${byEmailResult.error.message}`);
+  }
+
+  let byAuthRows: ProfileRow[] = [];
+  if (authIds.length > 0) {
+    const byAuthResult = await supabase
+      .from(TABLE.userInfo)
+      .select("id, email, auth_user_id")
+      .in("auth_user_id", authIds);
+    if (byAuthResult.error) {
+      throw new Error(`Reading linked user profiles failed: ${byAuthResult.error.message}`);
+    }
+    byAuthRows = (byAuthResult.data ?? []) as ProfileRow[];
+  }
+
+  const profileByEmail = new Map<string, ProfileRow>();
+  const profileByAuthId = new Map<string, ProfileRow>();
+  for (const profile of [
+    ...((byEmailResult.data ?? []) as ProfileRow[]),
+    ...byAuthRows,
+  ]) {
+    profileByEmail.set(profile.email.trim().toLowerCase(), profile);
+    if (profile.auth_user_id) profileByAuthId.set(profile.auth_user_id, profile);
+  }
+
+  for (const fixture of fixtures) {
+    const authUser = authByEmail.get(fixture.email);
+    const emailProfile = profileByEmail.get(fixture.email);
+    const authProfile = authUser ? profileByAuthId.get(authUser.id) : undefined;
+
+    if (emailProfile?.auth_user_id && emailProfile.auth_user_id !== authUser?.id) {
+      throw new Error(
+        `Profile "${fixture.email}" is linked to a different Auth user; refusing to overwrite it`
+      );
+    }
+    if (authProfile && authProfile.email.trim().toLowerCase() !== fixture.email) {
+      throw new Error(
+        `Auth user "${fixture.email}" is linked to profile "${authProfile.email}"; refusing to overwrite it`
+      );
+    }
+    if (emailProfile && authProfile && emailProfile.id !== authProfile.id) {
+      throw new Error(
+        `Auth and profile records for "${fixture.email}" resolve to different users`
+      );
+    }
+  }
+
+  return { authByEmail, profileByAuthId, profileByEmail };
+}
+
+async function loadDependencies(
+  supabase: SupabaseClient,
+  fixtures: SeedUser[],
+  allowPlannedDependencies: boolean
+): Promise<DependencyReferences> {
+  const membershipSlugs = [
+    ...new Set(
+      fixtures.flatMap((fixture) => [
+        ...(fixture.membershipSlug ? [fixture.membershipSlug] : []),
+        ...fixture.purchases.flatMap((purchase) =>
+          purchase.membershipSlug ? [purchase.membershipSlug] : []
+        ),
+      ])
+    ),
+  ];
+  const eventSlugs = [
+    ...new Set(
+      fixtures.flatMap((fixture) => [
+        ...fixture.registrations.map((registration) => registration.eventSlug),
+        ...fixture.purchases.flatMap((purchase) =>
+          purchase.eventSlug ? [purchase.eventSlug] : []
+        ),
+      ])
+    ),
+  ];
+
+  const [membershipResult, eventResult] = await Promise.all([
+    supabase
+      .from(TABLE.membershipTypes)
+      .select("id, slug")
+      .in("slug", membershipSlugs),
+    supabase.from(TABLE.events).select("id, slug").in("slug", eventSlugs),
+  ]);
+  if (membershipResult.error) {
+    throw new Error(`Reading membership dependencies failed: ${membershipResult.error.message}`);
+  }
+  if (eventResult.error) {
+    throw new Error(`Reading event dependencies failed: ${eventResult.error.message}`);
+  }
+
+  const membershipIds = new Map<string, string>();
+  for (const row of (membershipResult.data ?? []) as { id: string; slug: string }[]) {
+    membershipIds.set(row.slug, row.id);
+  }
+
+  const eventIds = new Map<string, string>();
+  for (const row of (eventResult.data ?? []) as { id: string; slug: string | null }[]) {
+    if (row.slug) eventIds.set(row.slug, row.id);
+  }
+
+  const missingMemberships = membershipSlugs.filter(
+    (slug) => !membershipIds.has(slug)
+  );
+  const missingEvents = eventSlugs.filter((slug) => !eventIds.has(slug));
+  const missingParents = [
+    ...missingMemberships.map((slug) => `membership:${slug}`),
+    ...missingEvents.map((slug) => `event:${slug}`),
+  ];
+
+  if (missingParents.length > 0) {
+    if (allowPlannedDependencies) {
+      return {
+        complete: false,
+        eventIds,
+        membershipIds,
+        questionIds: new Map(),
+        sessionIds: new Map(),
+      };
+    }
+    throw new Error(
+      `User seed dependencies are missing: ${missingParents.join(", ")}. ` +
+        "Run memberships/events first or include them in this seed run."
+    );
+  }
+
+  const eventIdValues = [...eventIds.values()];
+  const [questionResult, sessionResult] = await Promise.all([
+    supabase
+      .from(TABLE.eventApplicationQuestions)
+      .select("id, event_id, question")
+      .in("event_id", eventIdValues),
+    supabase
+      .from(TABLE.checkInSessions)
+      .select("id, event_id, name")
+      .in("event_id", eventIdValues),
+  ]);
+  if (questionResult.error) {
+    throw new Error(`Reading application dependencies failed: ${questionResult.error.message}`);
+  }
+  if (sessionResult.error) {
+    throw new Error(`Reading check-in dependencies failed: ${sessionResult.error.message}`);
+  }
+
+  const eventSlugById = new Map(
+    [...eventIds.entries()].map(([slug, id]) => [id, slug])
+  );
+  const questionIds = new Map<string, string>();
+  for (const row of (questionResult.data ?? []) as {
+    event_id: string;
+    id: string;
+    question: string;
+  }[]) {
+    const eventSlug = eventSlugById.get(row.event_id);
+    if (eventSlug) questionIds.set(key(eventSlug, row.question), row.id);
+  }
+
+  const sessionIds = new Map<string, string>();
+  for (const row of (sessionResult.data ?? []) as {
+    event_id: string;
+    id: string;
+    name: string;
+  }[]) {
+    const eventSlug = eventSlugById.get(row.event_id);
+    if (eventSlug) sessionIds.set(key(eventSlug, row.name), row.id);
+  }
+
+  const missingChildren: string[] = [];
+  for (const fixture of fixtures) {
+    for (const registration of fixture.registrations) {
+      for (const question of Object.keys(registration.responses ?? {})) {
+        if (!questionIds.has(key(registration.eventSlug, question))) {
+          missingChildren.push(`question:${registration.eventSlug}:${question}`);
+        }
+      }
+      for (const session of Object.keys(registration.checkIns ?? {})) {
+        if (!sessionIds.has(key(registration.eventSlug, session))) {
+          missingChildren.push(`session:${registration.eventSlug}:${session}`);
+        }
+      }
+    }
+  }
+
+  if (missingChildren.length > 0) {
+    if (allowPlannedDependencies) {
+      return { complete: false, eventIds, membershipIds, questionIds, sessionIds };
+    }
+    throw new Error(
+      `User seed dependencies are missing: ${missingChildren.join(", ")}. ` +
+        "Run events first or include them in this seed run."
+    );
+  }
+
+  return { complete: true, eventIds, membershipIds, questionIds, sessionIds };
+}
+
+function getMembershipExpiry(): string {
+  const expiry = new Date();
+  expiry.setUTCFullYear(expiry.getUTCFullYear() + 1);
+  return expiry.toISOString();
+}
+
+async function reconcileIdentities(
+  supabase: SupabaseClient,
+  fixtures: SeedUser[],
+  dependencies: DependencyReferences,
+  state: IdentityState
+): Promise<{ authUsers: Counts; profiles: Counts; profileIds: Map<string, string> }> {
+  const authUsers = countsFor(fixtures.length, state.authByEmail.size);
+  const profiles = countsFor(fixtures.length, state.profileByEmail.size);
+  const profileIds = new Map<string, string>();
+
+  for (const fixture of fixtures) {
+    let authUser = state.authByEmail.get(fixture.email);
+    const authAttributes = {
+      email: fixture.email,
+      password: fixture.password,
+      email_confirm: true,
+      user_metadata: { full_name: fixture.profile.name, seed_managed: true },
+    };
+
+    if (authUser) {
+      const { data, error } = await supabase.auth.admin.updateUserById(
+        authUser.id,
+        authAttributes
+      );
+      if (error) {
+        throw new Error(`Updating Auth user "${fixture.email}" failed: ${error.message}`);
+      }
+      authUser = data.user;
+    } else {
+      const { data, error } = await supabase.auth.admin.createUser(authAttributes);
+      if (error) {
+        throw new Error(`Creating Auth user "${fixture.email}" failed: ${error.message}`);
+      }
+      authUser = data.user;
+    }
+
+    const membershipTypeId = fixture.membershipSlug
+      ? dependencies.membershipIds.get(fixture.membershipSlug)
+      : null;
+    if (fixture.membershipSlug && !membershipTypeId) {
+      throw new Error(`No ID found for membership "${fixture.membershipSlug}"`);
+    }
+
+    const existingProfile = state.profileByEmail.get(fixture.email);
+    const payload = {
+      ...fixture.profile,
+      auth_user_id: authUser.id,
+      email: fixture.email,
+      membership_expires_at: membershipTypeId ? getMembershipExpiry() : null,
+      membership_pre_ordered_type_id: null,
+      membership_type_id: membershipTypeId,
+    };
+
+    if (existingProfile) {
+      const { data, error } = await supabase
+        .from(TABLE.userInfo)
+        .update(payload)
+        .eq("id", existingProfile.id)
+        .select("id")
+        .single();
+      if (error) {
+        throw new Error(`Updating profile "${fixture.email}" failed: ${error.message}`);
+      }
+      profileIds.set(fixture.email, (data as { id: string }).id);
+    } else {
+      const { data, error } = await supabase
+        .from(TABLE.userInfo)
+        .insert(payload)
+        .select("id")
+        .single();
+      if (error) {
+        throw new Error(`Creating profile "${fixture.email}" failed: ${error.message}`);
+      }
+      profileIds.set(fixture.email, (data as { id: string }).id);
+    }
+  }
+
+  return { authUsers, profiles, profileIds };
+}
+
+async function reconcilePurchases(
+  supabase: SupabaseClient,
+  fixtures: SeedUser[],
+  profileIds: Map<string, string>,
+  dependencies: DependencyReferences
+): Promise<{ counts: Counts; purchaseIds: Map<string, string> }> {
+  const purchases = fixtures.flatMap((fixture) =>
+    fixture.purchases.map((purchase) => ({ fixture, purchase }))
+  );
+  const keys = purchases.map(({ purchase }) => purchase.idempotencyKey);
+  const { data: existing, error: readError } = await supabase
+    .from(TABLE.purchases)
+    .select("id, idempotency_key, user_id")
+    .in("idempotency_key", keys);
+  if (readError) throw new Error(`Reading purchases failed: ${readError.message}`);
+
+  const existingByKey = new Map(
+    ((existing ?? []) as { id: string; idempotency_key: string; user_id: string }[]).map(
+      (row) => [row.idempotency_key, row]
+    )
+  );
+
+  const rows = purchases.map(({ fixture, purchase }) => {
+    const userId = profileIds.get(fixture.email);
+    if (!userId) throw new Error(`No profile ID found for "${fixture.email}"`);
+
+    const existingPurchase = existingByKey.get(purchase.idempotencyKey);
+    if (existingPurchase && existingPurchase.user_id !== userId) {
+      throw new Error(
+        `Purchase key "${purchase.idempotencyKey}" belongs to another user`
+      );
+    }
+
+    return {
+      amount_cents: purchase.amountCents,
+      created_at: purchase.createdAt,
+      currency: "CAD",
+      event_id: purchase.eventSlug
+        ? dependencies.eventIds.get(purchase.eventSlug)
+        : null,
+      failure_reason: purchase.failureReason ?? null,
+      fulfilled_at: purchase.fulfilledAt ?? null,
+      idempotency_key: purchase.idempotencyKey,
+      kind: purchase.kind,
+      membership_type_id: purchase.membershipSlug
+        ? dependencies.membershipIds.get(purchase.membershipSlug)
+        : null,
+      square_customer_id: fixture.profile.square_customer_id ?? null,
+      square_payment_id: purchase.squarePaymentId ?? null,
+      status: purchase.status,
+      user_id: userId,
+    };
+  });
+
+  const { data, error } = await supabase
+    .from(TABLE.purchases)
+    .upsert(rows, { onConflict: "idempotency_key" })
+    .select("id, idempotency_key");
+  if (error) throw new Error(`Upserting purchases failed: ${error.message}`);
+
+  const purchaseIds = new Map<string, string>();
+  for (const row of (data ?? []) as { id: string; idempotency_key: string }[]) {
+    purchaseIds.set(row.idempotency_key, row.id);
+  }
+
+  return { counts: countsFor(rows.length, existingByKey.size), purchaseIds };
+}
+
+async function reconcileRegistrations(
+  supabase: SupabaseClient,
+  fixtures: SeedUser[],
+  profileIds: Map<string, string>,
+  purchaseIds: Map<string, string>,
+  dependencies: DependencyReferences
+): Promise<{ counts: Counts; registrationIds: Map<string, string> }> {
+  const userIds = [...profileIds.values()];
+  const eventIds = [...dependencies.eventIds.values()];
+  const { data: existing, error: readError } = await supabase
+    .from(TABLE.eventRegistrations)
+    .select("id, event_id, user_id")
+    .in("user_id", userIds)
+    .in("event_id", eventIds);
+  if (readError) {
+    throw new Error(`Reading event registrations failed: ${readError.message}`);
+  }
+
+  const existingKeys = new Set(
+    ((existing ?? []) as { event_id: string; user_id: string }[]).map((row) =>
+      key(row.user_id, row.event_id)
+    )
+  );
+  const rows = fixtures.flatMap((fixture) => {
+    const userId = profileIds.get(fixture.email);
+    if (!userId) throw new Error(`No profile ID found for "${fixture.email}"`);
+
+    return fixture.registrations.map((registration) => {
+      const eventId = dependencies.eventIds.get(registration.eventSlug);
+      if (!eventId) throw new Error(`No event ID found for "${registration.eventSlug}"`);
+
+      const purchaseId = registration.purchaseKey
+        ? purchaseIds.get(registration.purchaseKey)
+        : null;
+      if (registration.purchaseKey && !purchaseId) {
+        throw new Error(`No purchase ID found for "${registration.purchaseKey}"`);
+      }
+
+      const reviewerId = registration.reviewerEmail
+        ? profileIds.get(registration.reviewerEmail)
+        : null;
+      if (registration.reviewerEmail && !reviewerId) {
+        throw new Error(`No reviewer profile found for "${registration.reviewerEmail}"`);
+      }
+
+      return {
+        attending: registration.attending,
+        event_id: eventId,
+        purchase_id: purchaseId,
+        reviewer_id: reviewerId,
+        status: registration.status,
+        user_id: userId,
+      };
+    });
+  });
+
+  const { data, error } = await supabase
+    .from(TABLE.eventRegistrations)
+    .upsert(rows, { onConflict: "event_id,user_id" })
+    .select("id, event_id, user_id");
+  if (error) throw new Error(`Upserting event registrations failed: ${error.message}`);
+
+  const eventSlugById = new Map(
+    [...dependencies.eventIds.entries()].map(([slug, id]) => [id, slug])
+  );
+  const emailByProfileId = new Map(
+    [...profileIds.entries()].map(([email, id]) => [id, email])
+  );
+  const registrationIds = new Map<string, string>();
+  for (const row of (data ?? []) as { event_id: string; id: string; user_id: string }[]) {
+    const email = emailByProfileId.get(row.user_id);
+    const eventSlug = eventSlugById.get(row.event_id);
+    if (email && eventSlug) registrationIds.set(key(email, eventSlug), row.id);
+  }
+
+  return {
+    counts: countsFor(rows.length, existingKeys.size),
+    registrationIds,
+  };
+}
+
+async function reconcileResponses(
+  supabase: SupabaseClient,
+  fixtures: SeedUser[],
+  registrationIds: Map<string, string>,
+  dependencies: DependencyReferences
+): Promise<Counts> {
+  const rows = fixtures.flatMap((fixture) =>
+    fixture.registrations.flatMap((registration) => {
+      const registrationId = registrationIds.get(
+        key(fixture.email, registration.eventSlug)
+      );
+      if (!registrationId) {
+        throw new Error(
+          `No registration ID found for "${fixture.email}" and "${registration.eventSlug}"`
+        );
+      }
+
+      return Object.entries(registration.responses ?? {}).map(
+        ([question, response]) => {
+          const questionId = dependencies.questionIds.get(
+            key(registration.eventSlug, question)
+          );
+          if (!questionId) {
+            throw new Error(
+              `No question ID found for "${registration.eventSlug}" and "${question}"`
+            );
+          }
+          return {
+            event_application_question_id: questionId,
+            event_registration_id: registrationId,
+            response,
+          };
+        }
+      );
+    })
+  );
+
+  if (rows.length === 0) return emptyCounts();
+  const registrationIdValues = [...new Set(rows.map((row) => row.event_registration_id))];
+  const { data: existing, error: readError } = await supabase
+    .from(TABLE.eventApplicationResponses)
+    .select("event_application_question_id, event_registration_id")
+    .in("event_registration_id", registrationIdValues);
+  if (readError) {
+    throw new Error(`Reading application responses failed: ${readError.message}`);
+  }
+
+  const existingKeys = new Set(
+    ((existing ?? []) as {
+      event_application_question_id: string;
+      event_registration_id: string;
+    }[]).map((row) =>
+      key(row.event_application_question_id, row.event_registration_id)
+    )
+  );
+  const existingDesiredCount = rows.filter((row) =>
+    existingKeys.has(
+      key(row.event_application_question_id, row.event_registration_id)
+    )
+  ).length;
+
+  const { error } = await supabase.from(TABLE.eventApplicationResponses).upsert(rows, {
+    onConflict: "event_application_question_id,event_registration_id",
+  });
+  if (error) throw new Error(`Upserting application responses failed: ${error.message}`);
+
+  return countsFor(rows.length, existingDesiredCount);
+}
+
+async function reconcileCheckIns(
+  supabase: SupabaseClient,
+  fixtures: SeedUser[],
+  registrationIds: Map<string, string>,
+  dependencies: DependencyReferences
+): Promise<Counts> {
+  const rows = fixtures.flatMap((fixture) =>
+    fixture.registrations.flatMap((registration) => {
+      const registrationId = registrationIds.get(
+        key(fixture.email, registration.eventSlug)
+      );
+      if (!registrationId) {
+        throw new Error(
+          `No registration ID found for "${fixture.email}" and "${registration.eventSlug}"`
+        );
+      }
+
+      return Object.entries(registration.checkIns ?? {}).map(
+        ([sessionName, checkedInAt]) => {
+          const sessionId = dependencies.sessionIds.get(
+            key(registration.eventSlug, sessionName)
+          );
+          if (!sessionId) {
+            throw new Error(
+              `No session ID found for "${registration.eventSlug}" and "${sessionName}"`
+            );
+          }
+          return {
+            check_in_session_id: sessionId,
+            checked_in_at: checkedInAt,
+            event_registration_id: registrationId,
+          };
+        }
+      );
+    })
+  );
+
+  if (rows.length === 0) return emptyCounts();
+  const registrationIdValues = [...new Set(rows.map((row) => row.event_registration_id))];
+  const { data: existing, error: readError } = await supabase
+    .from(TABLE.checkIns)
+    .select("check_in_session_id, event_registration_id")
+    .in("event_registration_id", registrationIdValues);
+  if (readError) throw new Error(`Reading check-ins failed: ${readError.message}`);
+
+  const existingKeys = new Set(
+    ((existing ?? []) as {
+      check_in_session_id: string;
+      event_registration_id: string;
+    }[]).map((row) => key(row.check_in_session_id, row.event_registration_id))
+  );
+  const existingDesiredCount = rows.filter((row) =>
+    existingKeys.has(key(row.check_in_session_id, row.event_registration_id))
+  ).length;
+
+  const { error } = await supabase.from(TABLE.checkIns).upsert(rows, {
+    onConflict: "event_registration_id,check_in_session_id",
+  });
+  if (error) throw new Error(`Upserting check-ins failed: ${error.message}`);
+
+  return countsFor(rows.length, existingDesiredCount);
+}
+
+async function planDryRun(
+  supabase: SupabaseClient,
+  fixtures: SeedUser[],
+  dependencies: DependencyReferences,
+  state: IdentityState
+): Promise<UserSeedSummary> {
+  const totals = getUserFixtureTotals(fixtures);
+  const summary = emptySummary();
+  summary.authUsers = countsFor(totals.authUsers, state.authByEmail.size);
+  summary.profiles = countsFor(totals.profiles, state.profileByEmail.size);
+
+  if (!dependencies.complete) {
+    summary.purchases = createdCounts(totals.purchases);
+    summary.registrations = createdCounts(totals.registrations);
+    summary.responses = createdCounts(totals.responses);
+    summary.checkIns = createdCounts(totals.checkIns);
+    return summary;
+  }
+
+  const profileIds = new Map<string, string>();
+  for (const fixture of fixtures) {
+    const profile = state.profileByEmail.get(fixture.email);
+    if (profile) profileIds.set(fixture.email, profile.id);
+  }
+
+  const purchaseKeys = fixtures.flatMap((fixture) =>
+    fixture.purchases.map((purchase) => purchase.idempotencyKey)
+  );
+  const purchaseResult = await supabase
+    .from(TABLE.purchases)
+    .select("idempotency_key")
+    .in("idempotency_key", purchaseKeys);
+  if (purchaseResult.error) {
+    throw new Error(`Reading purchases failed: ${purchaseResult.error.message}`);
+  }
+  summary.purchases = countsFor(
+    totals.purchases,
+    (purchaseResult.data ?? []).length
+  );
+
+  const existingRegistrationByKey = new Map<string, string>();
+  if (profileIds.size > 0) {
+    const registrationResult = await supabase
+      .from(TABLE.eventRegistrations)
+      .select("id, event_id, user_id")
+      .in("user_id", [...profileIds.values()])
+      .in("event_id", [...dependencies.eventIds.values()]);
+    if (registrationResult.error) {
+      throw new Error(
+        `Reading event registrations failed: ${registrationResult.error.message}`
+      );
+    }
+    const emailByProfileId = new Map(
+      [...profileIds.entries()].map(([email, id]) => [id, email])
+    );
+    const eventSlugById = new Map(
+      [...dependencies.eventIds.entries()].map(([slug, id]) => [id, slug])
+    );
+    for (const row of (registrationResult.data ?? []) as {
+      event_id: string;
+      id: string;
+      user_id: string;
+    }[]) {
+      const email = emailByProfileId.get(row.user_id);
+      const eventSlug = eventSlugById.get(row.event_id);
+      if (email && eventSlug) {
+        existingRegistrationByKey.set(key(email, eventSlug), row.id);
+      }
+    }
+  }
+
+  const desiredRegistrationKeys = fixtures.flatMap((fixture) =>
+    fixture.registrations.map((registration) =>
+      key(fixture.email, registration.eventSlug)
+    )
+  );
+  const existingRegistrationCount = desiredRegistrationKeys.filter((value) =>
+    existingRegistrationByKey.has(value)
+  ).length;
+  summary.registrations = countsFor(
+    totals.registrations,
+    existingRegistrationCount
+  );
+
+  const existingRegistrationIds = [...existingRegistrationByKey.values()];
+  if (existingRegistrationIds.length === 0) {
+    summary.responses = createdCounts(totals.responses);
+    summary.checkIns = createdCounts(totals.checkIns);
+    return summary;
+  }
+
+  const [responseResult, checkInResult] = await Promise.all([
+    supabase
+      .from(TABLE.eventApplicationResponses)
+      .select("event_application_question_id, event_registration_id")
+      .in("event_registration_id", existingRegistrationIds),
+    supabase
+      .from(TABLE.checkIns)
+      .select("check_in_session_id, event_registration_id")
+      .in("event_registration_id", existingRegistrationIds),
+  ]);
+  if (responseResult.error) {
+    throw new Error(`Reading application responses failed: ${responseResult.error.message}`);
+  }
+  if (checkInResult.error) {
+    throw new Error(`Reading check-ins failed: ${checkInResult.error.message}`);
+  }
+
+  const responseKeys = new Set(
+    ((responseResult.data ?? []) as {
+      event_application_question_id: string;
+      event_registration_id: string;
+    }[]).map((row) =>
+      key(row.event_application_question_id, row.event_registration_id)
+    )
+  );
+  const checkInKeys = new Set(
+    ((checkInResult.data ?? []) as {
+      check_in_session_id: string;
+      event_registration_id: string;
+    }[]).map((row) => key(row.check_in_session_id, row.event_registration_id))
+  );
+
+  let existingResponses = 0;
+  let existingCheckIns = 0;
+  for (const fixture of fixtures) {
+    for (const registration of fixture.registrations) {
+      const registrationId = existingRegistrationByKey.get(
+        key(fixture.email, registration.eventSlug)
+      );
+      if (!registrationId) continue;
+
+      for (const question of Object.keys(registration.responses ?? {})) {
+        const questionId = dependencies.questionIds.get(
+          key(registration.eventSlug, question)
+        );
+        if (questionId && responseKeys.has(key(questionId, registrationId))) {
+          existingResponses += 1;
+        }
+      }
+      for (const session of Object.keys(registration.checkIns ?? {})) {
+        const sessionId = dependencies.sessionIds.get(
+          key(registration.eventSlug, session)
+        );
+        if (sessionId && checkInKeys.has(key(sessionId, registrationId))) {
+          existingCheckIns += 1;
+        }
+      }
+    }
+  }
+
+  summary.responses = countsFor(totals.responses, existingResponses);
+  summary.checkIns = countsFor(totals.checkIns, existingCheckIns);
+  return summary;
+}
+
+export async function reconcileUserFixtures(
+  supabase: SupabaseClient,
+  fixtures: SeedUser[],
+  options: UserSeedOptions
+): Promise<UserSeedSummary> {
+  const [dependencies, identityState] = await Promise.all([
+    loadDependencies(supabase, fixtures, options.allowPlannedDependencies),
+    inspectIdentityState(supabase, fixtures),
+  ]);
+
+  if (options.dryRun) {
+    return planDryRun(supabase, fixtures, dependencies, identityState);
+  }
+  if (!dependencies.complete) {
+    throw new Error("User seed dependencies were planned but not written");
+  }
+
+  const identity = await reconcileIdentities(
+    supabase,
+    fixtures,
+    dependencies,
+    identityState
+  );
+  const purchases = await reconcilePurchases(
+    supabase,
+    fixtures,
+    identity.profileIds,
+    dependencies
+  );
+  const registrations = await reconcileRegistrations(
+    supabase,
+    fixtures,
+    identity.profileIds,
+    purchases.purchaseIds,
+    dependencies
+  );
+  const responses = await reconcileResponses(
+    supabase,
+    fixtures,
+    registrations.registrationIds,
+    dependencies
+  );
+  const checkIns = await reconcileCheckIns(
+    supabase,
+    fixtures,
+    registrations.registrationIds,
+    dependencies
+  );
+
+  return {
+    authUsers: identity.authUsers,
+    profiles: identity.profiles,
+    purchases: purchases.counts,
+    registrations: registrations.counts,
+    responses,
+    checkIns,
+  };
+}

--- a/scripts/seed/lib/relative-dates.ts
+++ b/scripts/seed/lib/relative-dates.ts
@@ -1,0 +1,43 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function startOfUtcDay(value: Date): Date {
+  if (Number.isNaN(value.getTime())) throw new Error("Invalid seed reference date");
+  return new Date(
+    Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate())
+  );
+}
+
+export function addDays(value: Date, days: number): Date {
+  return new Date(value.getTime() + days * DAY_MS);
+}
+
+export function addMonths(value: Date, months: number): Date {
+  const result = new Date(value);
+  const originalDay = result.getUTCDate();
+  result.setUTCDate(1);
+  result.setUTCMonth(result.getUTCMonth() + months);
+
+  const lastDay = new Date(
+    Date.UTC(result.getUTCFullYear(), result.getUTCMonth() + 1, 0)
+  ).getUTCDate();
+  result.setUTCDate(Math.min(originalDay, lastDay));
+  return result;
+}
+
+export function dateString(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+export function timestamp(
+  value: Date,
+  hour = 0,
+  minute = 0
+): string {
+  const result = new Date(value);
+  result.setUTCHours(hour, minute, 0, 0);
+  return result.toISOString();
+}
+
+export function eventYear(value: Date): number {
+  return value.getUTCFullYear();
+}

--- a/scripts/seed/lib/user-fixtures.test.ts
+++ b/scripts/seed/lib/user-fixtures.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { membershipTypes } from "../data/membership-types.ts";
+import { buildSeedEvents } from "../data/events.ts";
+import { buildSeedUsers } from "../data/users.ts";
+import {
+  classifySeedEvent,
+  getUserFixtureTotals,
+  validateUserFixtures,
+} from "./user-fixtures.ts";
+
+const fixedNow = new Date("2026-07-31T19:00:00.000Z");
+const seedEvents = buildSeedEvents(fixedNow);
+const seedUsers = buildSeedUsers(seedEvents, fixedNow);
+
+describe("user seed fixtures", () => {
+  it("reference valid memberships, events, questions, sessions, and purchases", () => {
+    expect(() =>
+      validateUserFixtures(seedUsers, seedEvents, membershipTypes, fixedNow)
+    ).not.toThrow();
+  });
+
+  it("reports the representative dataset totals", () => {
+    expect(getUserFixtureTotals(seedUsers)).toEqual({
+      authUsers: 2,
+      profiles: 2,
+      purchases: 8,
+      registrations: 11,
+      responses: 22,
+      checkIns: 4,
+    });
+  });
+
+  it("gives every user purchased coverage across all timeline phases", () => {
+    const eventBySlug = new Map(
+      seedEvents.map((event) => [event.event.slug, event])
+    );
+
+    for (const user of seedUsers) {
+      const purchaseByKey = new Map(
+        user.purchases.map((purchase) => [purchase.idempotencyKey, purchase])
+      );
+      const phases = new Set(
+        user.registrations.flatMap((registration) => {
+          const purchase = registration.purchaseKey
+            ? purchaseByKey.get(registration.purchaseKey)
+            : null;
+          const event = eventBySlug.get(registration.eventSlug);
+          return registration.status === "accepted" &&
+            purchase?.status === "completed" &&
+            event
+            ? [classifySeedEvent(event, fixedNow)]
+            : [];
+        })
+      );
+
+      expect(phases).toEqual(new Set(["past", "ongoing", "upcoming"]));
+    }
+  });
+
+  it("rejects duplicate identity and purchase keys", () => {
+    const duplicateEmail = structuredClone(seedUsers);
+    duplicateEmail[1].email = duplicateEmail[0].email;
+    expect(() =>
+      validateUserFixtures(duplicateEmail, seedEvents, membershipTypes, fixedNow)
+    ).toThrow("Duplicate user email");
+
+    const duplicatePurchase = structuredClone(seedUsers);
+    duplicatePurchase[1].purchases[0].idempotencyKey =
+      duplicatePurchase[0].purchases[0].idempotencyKey;
+    expect(() =>
+      validateUserFixtures(
+        duplicatePurchase,
+        seedEvents,
+        membershipTypes,
+        fixedNow
+      )
+    ).toThrow("Duplicate purchase idempotency key");
+  });
+
+  it("rejects invalid membership and registration relationships", () => {
+    const nonMemberPurchase = structuredClone(seedUsers);
+    nonMemberPurchase[1].purchases.push({
+      ...nonMemberPurchase[0].purchases[0],
+      idempotencyKey: "seed:invalid:membership",
+    });
+    expect(() =>
+      validateUserFixtures(
+        nonMemberPurchase,
+        seedEvents,
+        membershipTypes,
+        fixedNow
+      )
+    ).toThrow("cannot have a membership purchase");
+
+    const wrongTicket = structuredClone(seedUsers);
+    wrongTicket[1].registrations[0].purchaseKey =
+      "seed:event:not-member:thinkbox-office-tour-2027:failed";
+    expect(() =>
+      validateUserFixtures(wrongTicket, seedEvents, membershipTypes, fixedNow)
+    ).toThrow("invalid purchase link");
+  });
+});

--- a/scripts/seed/lib/user-fixtures.ts
+++ b/scripts/seed/lib/user-fixtures.ts
@@ -1,0 +1,249 @@
+import type { SeedUser } from "../data/users.ts";
+import type { SeedEvent } from "../data/events.ts";
+import type { TablesInsert } from "../../../src/lib/supabase/database.types.ts";
+
+export interface UserFixtureTotals {
+  authUsers: number;
+  profiles: number;
+  purchases: number;
+  registrations: number;
+  responses: number;
+  checkIns: number;
+}
+
+export type SeedEventPhase = "past" | "ongoing" | "upcoming";
+
+export function classifySeedEvent(event: SeedEvent, now: Date): SeedEventPhase {
+  const start = new Date(`${event.event.start_date}T00:00:00.000Z`).getTime();
+  const end = new Date(`${event.event.end_date}T23:59:59.999Z`).getTime();
+  const current = now.getTime();
+
+  if (start <= current && current <= end) return "ongoing";
+  return start > current ? "upcoming" : "past";
+}
+
+export function getUserFixtureTotals(users: SeedUser[]): UserFixtureTotals {
+  return users.reduce<UserFixtureTotals>(
+    (totals, user) => {
+      totals.authUsers += 1;
+      totals.profiles += 1;
+      totals.purchases += user.purchases.length;
+      totals.registrations += user.registrations.length;
+
+      for (const registration of user.registrations) {
+        totals.responses += Object.keys(registration.responses ?? {}).length;
+        totals.checkIns += Object.keys(registration.checkIns ?? {}).length;
+      }
+
+      return totals;
+    },
+    {
+      authUsers: 0,
+      profiles: 0,
+      purchases: 0,
+      registrations: 0,
+      responses: 0,
+      checkIns: 0,
+    }
+  );
+}
+
+function assertUnique(values: string[], label: string): void {
+  const seen = new Set<string>();
+
+  for (const value of values) {
+    if (seen.has(value)) {
+      throw new Error(`Duplicate ${label} "${value}" in user seed data`);
+    }
+    seen.add(value);
+  }
+}
+
+export function validateUserFixtures(
+  users: SeedUser[],
+  events: SeedEvent[],
+  memberships: TablesInsert<"membership_types">[],
+  now = new Date()
+): void {
+  const eventBySlug = new Map(events.map((event) => [event.event.slug, event]));
+  const membershipBySlug = new Map(
+    memberships.map((membership) => [membership.slug, membership])
+  );
+  const membershipSlugs = new Set(membershipBySlug.keys());
+  const normalizedEmails = users.map((user) => user.email.trim().toLowerCase());
+
+  assertUnique(normalizedEmails, "user email");
+  assertUnique(
+    users.flatMap((user) => user.purchases.map((purchase) => purchase.idempotencyKey)),
+    "purchase idempotency key"
+  );
+
+  for (const user of users) {
+    if (user.email !== user.email.trim().toLowerCase()) {
+      throw new Error(`Seed user email must be normalized: "${user.email}"`);
+    }
+    if (user.password.length < 6) {
+      throw new Error(`Seed password for "${user.email}" must be at least 6 characters`);
+    }
+    if (user.membershipSlug && !membershipSlugs.has(user.membershipSlug)) {
+      throw new Error(
+        `Unknown membership slug "${user.membershipSlug}" for "${user.email}"`
+      );
+    }
+
+    const purchaseByKey = new Map(
+      user.purchases.map((purchase) => [purchase.idempotencyKey, purchase])
+    );
+    const registrationSlugs = user.registrations.map(
+      (registration) => registration.eventSlug
+    );
+    assertUnique(registrationSlugs, `registration event for ${user.email}`);
+
+    const membershipPurchases = user.purchases.filter(
+      (purchase) => purchase.kind === "membership"
+    );
+    if (!user.membershipSlug && membershipPurchases.length > 0) {
+      throw new Error(`Non-member "${user.email}" cannot have a membership purchase`);
+    }
+    if (
+      user.membershipSlug &&
+      !membershipPurchases.some(
+        (purchase) =>
+          purchase.membershipSlug === user.membershipSlug &&
+          purchase.status === "completed"
+      )
+    ) {
+      throw new Error(
+        `Member "${user.email}" needs a completed ${user.membershipSlug} purchase`
+      );
+    }
+
+    for (const purchase of user.purchases) {
+      const hasEvent = Boolean(purchase.eventSlug);
+      const hasMembership = Boolean(purchase.membershipSlug);
+
+      if (
+        (purchase.kind === "event_ticket" && (!hasEvent || hasMembership)) ||
+        (purchase.kind === "membership" && (!hasMembership || hasEvent))
+      ) {
+        throw new Error(
+          `Purchase "${purchase.idempotencyKey}" has invalid kind references`
+        );
+      }
+      if (purchase.eventSlug && !eventBySlug.has(purchase.eventSlug)) {
+        throw new Error(
+          `Purchase "${purchase.idempotencyKey}" references unknown event "${purchase.eventSlug}"`
+        );
+      }
+      if (purchase.membershipSlug && !membershipSlugs.has(purchase.membershipSlug)) {
+        throw new Error(
+          `Purchase "${purchase.idempotencyKey}" references unknown membership "${purchase.membershipSlug}"`
+        );
+      }
+
+      const expectedAmount = purchase.eventSlug
+        ? Number(
+            user.membershipSlug
+              ? eventBySlug.get(purchase.eventSlug)?.event.member_price
+              : eventBySlug.get(purchase.eventSlug)?.event.regular_price
+          ) * 100
+        : Number(
+            membershipBySlug.get(purchase.membershipSlug ?? "")?.price
+          ) * 100;
+      if (purchase.amountCents !== expectedAmount) {
+        throw new Error(
+          `Purchase "${purchase.idempotencyKey}" amount ${purchase.amountCents} does not match expected ${expectedAmount}`
+        );
+      }
+    }
+
+    for (const registration of user.registrations) {
+      const event = eventBySlug.get(registration.eventSlug);
+      if (!event) {
+        throw new Error(
+          `Registration for "${user.email}" references unknown event "${registration.eventSlug}"`
+        );
+      }
+
+      if (registration.purchaseKey) {
+        const purchase = purchaseByKey.get(registration.purchaseKey);
+        if (
+          !purchase ||
+          purchase.kind !== "event_ticket" ||
+          purchase.eventSlug !== registration.eventSlug ||
+          purchase.status !== "completed"
+        ) {
+          throw new Error(
+            `Registration for "${registration.eventSlug}" has an invalid purchase link`
+          );
+        }
+      }
+
+      const questionByText = new Map(
+        event.applicationQuestions.map((question) => [question.question, question])
+      );
+      const responses = registration.responses ?? {};
+
+      for (const question of event.applicationQuestions) {
+        if (question.is_required && !responses[question.question]?.trim()) {
+          throw new Error(
+            `Registration for "${registration.eventSlug}" is missing required response "${question.question}"`
+          );
+        }
+      }
+
+      for (const [questionText, response] of Object.entries(responses)) {
+        const question = questionByText.get(questionText);
+        if (!question) {
+          throw new Error(
+            `Registration for "${registration.eventSlug}" references unknown question "${questionText}"`
+          );
+        }
+
+        if (question.response_options && response) {
+          const selected =
+            question.response_type === "multi_select"
+              ? response.split(",").map((value) => value.trim())
+              : [response];
+          const invalid = selected.find(
+            (value) => !question.response_options?.includes(value)
+          );
+          if (invalid) {
+            throw new Error(
+              `Response "${invalid}" is invalid for question "${questionText}"`
+            );
+          }
+        }
+      }
+
+      const sessionNames = new Set(
+        event.checkInSessions.map((session) => session.name)
+      );
+      for (const sessionName of Object.keys(registration.checkIns ?? {})) {
+        if (!sessionNames.has(sessionName)) {
+          throw new Error(
+            `Registration for "${registration.eventSlug}" references unknown check-in session "${sessionName}"`
+          );
+        }
+      }
+    }
+
+    const purchasedPhases = new Set<SeedEventPhase>();
+    for (const registration of user.registrations) {
+      if (registration.status !== "accepted" || !registration.purchaseKey) continue;
+      const purchase = purchaseByKey.get(registration.purchaseKey);
+      const event = eventBySlug.get(registration.eventSlug);
+      if (purchase?.status === "completed" && event) {
+        purchasedPhases.add(classifySeedEvent(event, now));
+      }
+    }
+
+    for (const phase of ["past", "ongoing", "upcoming"] as const) {
+      if (!purchasedPhases.has(phase)) {
+        throw new Error(
+          `User "${user.email}" needs a completed purchased ${phase} registration`
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add two idempotent local Auth/profile fixtures with memberships, purchases, registrations, application responses, and check-ins
- generate 12 event fixtures relative to each seed run, covering past, ongoing, upcoming, and long-open registration states
- keep known-password users local-only and validate fixture relationships and prices before writes
- add fixed-clock coverage for event phases and per-user purchased event coverage

## Verification
- pnpm exec tsc --noEmit
- pnpm test (81 tests passed)
- pnpm lint (passes with one existing no-img-element warning)
- pnpm seed -- --dry-run
- pnpm seed twice with zero creates on the second run
- authenticated both seeded users and verified purchased past, ongoing, and upcoming events